### PR TITLE
Added merge option to setObjectProp

### DIFF
--- a/packages/ra-data-simple-prisma/src/extractWhere.ts
+++ b/packages/ra-data-simple-prisma/src/extractWhere.ts
@@ -20,7 +20,7 @@ export const extractWhere = (req: GetListRequest | GetManyReferenceRequest) => {
       const hasOperator = logicalOperators.some((operator) => {
         if (colName.endsWith(`_${operator}`)) {
           [colName] = colName.split(`_${operator}`);
-          setObjectProp(where, colName, { [operator]: value });
+          setObjectProp(where, colName, { [operator]: value }, { merge: true });
           return true;
         }
       });


### PR DESCRIPTION
Without `{ merge: true }`, the column is overwritten if multiple keys with the same name (but different operators) are present.