### PR TITLE
Fix bug in research

### DIFF
--- a/packages/ra-data-simple-prisma/src/extractWhere.ts
+++ b/packages/ra-data-simple-prisma/src/extractWhere.ts
@@ -43,7 +43,7 @@ export const extractWhere = (req: GetListRequest | GetManyReferenceRequest) => {
       } else if (Array.isArray(value)) {
         setObjectProp(where, colName, { in: value });
       } else if (typeof value === "string") {
-        setObjectProp(where, colName, { contains: value, mode: "insensitive" });
+        setObjectProp(where, colName, { contains: value});
       } else if (isObject(value)) {
         // if object then it's a Json field, this is EXPERIMENTAL and works only for Postgres
         // https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filter-on-object-property


### PR DESCRIPTION
Using : `@prisma/client` : `4.1.1`

Error : 
```
const [data, total] = await Promise.all([
→ 414   table.findMany(queryArgs.findManyArg){
          select: undefined,
          include: undefined,
          where: {
            nom: {
              contains: '1',
              mode: 'insensitive'
              ~~~~
            }
          },
          skip: 0,
          take: 100,
          orderBy: {
            nom: 'asc'
          }
        })
Unknown arg `mode` in where.nom.mode for type StringFilter. Did you mean `lte`? Available args:
type StringFilter {
  equals?: String
  in?: List<String>
  notIn?: List<String>
  lt?: String
  lte?: String
  gt?: String
  gte?: String
  contains?: String
  startsWith?: String
  endsWith?: String
  not?: String | NestedStringFilter
}
```