### PR TITLE
Add headers option to dataProvider for axios

### DIFF
--- a/packages/ra-data-simple-prisma/src/dataProvider.ts
+++ b/packages/ra-data-simple-prisma/src/dataProvider.ts
@@ -6,10 +6,12 @@ import type {
   AxiosInterceptorOptions,
   AxiosRequestConfig,
   AxiosResponse,
+  AxiosRequestHeaders,
 } from "axios";
 
 export const dataProvider = (
   endpoint: string,
+  headers?: AxiosRequestHeaders,
   options?: {
     resourceToModelMap?: Record<string, string>;
     axiosInterceptors?: {
@@ -30,6 +32,7 @@ export const dataProvider = (
 ): DataProvider => {
   const apiService = axios.create({
     baseURL: endpoint,
+    headers,
   });
 
   apiService.interceptors.response.use((res) => res.data);

--- a/packages/ra-data-simple-prisma/src/dataProvider.ts
+++ b/packages/ra-data-simple-prisma/src/dataProvider.ts
@@ -11,8 +11,8 @@ import type {
 
 export const dataProvider = (
   endpoint: string,
-  headers?: AxiosRequestHeaders,
   options?: {
+    headers?: AxiosRequestHeaders;
     resourceToModelMap?: Record<string, string>;
     axiosInterceptors?: {
       response?: {


### PR DESCRIPTION
The headers parameter can be useful for many cases, especially for authorization via tokens