### PR TITLE
Update logic to also account for prisma enums

### DIFF
--- a/packages/ra-data-simple-prisma/src/extractWhere.ts
+++ b/packages/ra-data-simple-prisma/src/extractWhere.ts
@@ -3,7 +3,7 @@ import { isNotField } from "./lib/isNotField";
 import { isObject } from "./lib/isObject";
 import setObjectProp from "set-value";
 
-const logicalOperators = ["gte", "lte", "lt", "gt"];
+const logicalOperators = ["gte", "lte", "lt", "gt", "enum"];
 
 export type FilterMode = "insensitive" | "default" | undefined;
 
@@ -31,7 +31,9 @@ export const extractWhere = (
       const hasOperator = logicalOperators.some((operator) => {
         if (colName.endsWith(`_${operator}`)) {
           [colName] = colName.split(`_${operator}`);
-          setObjectProp(where, colName, { [operator]: value }, { merge: true });
+          operator === "enum" 
+            ? setObjectProp(where, colName, value)
+            : setObjectProp(where, colName, { [operator]: value }, { merge: true });
           return true;
         }
       });


### PR DESCRIPTION
Prisma enums cannot use contain, even though when filtering they look like strings. As such we have to treat them different and use equals, so I propose adding an enum operator to differentiate when filtering by an enum column. Currently if you try to filter by an enum column at all, the query will just error out