### PR TITLE
Suggestion: Have all request handlers return the actual data they put on the response

### DIFF
--- a/packages/ra-data-simple-prisma/src/createHandler.ts
+++ b/packages/ra-data-simple-prisma/src/createHandler.ts
@@ -151,5 +151,7 @@ export const createHandler = async <Args extends CreateArgs>(
     await auditHandler(req, options?.audit, created);
   }
 
-  res.json({ data: created });
+  const response = { data: created };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/deleteHandler.ts
+++ b/packages/ra-data-simple-prisma/src/deleteHandler.ts
@@ -39,5 +39,7 @@ export const deleteHandler = async <
     await auditHandler(req, options?.audit);
   }
 
-  res.json({ data: deleted });
+  const response = { data: deleted };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/deleteManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/deleteManyHandler.ts
@@ -1,5 +1,5 @@
 import { AuditOptions } from "./audit/types";
-import { DeleteManyRequest, DeleteRequest, Response } from "./Http";
+import { DeleteManyRequest, Response } from "./Http";
 import { auditHandler } from "./audit/auditHandler";
 
 export type DeleteManyOptions = {
@@ -33,5 +33,7 @@ export const deleteManyHandler = async (
 
   // react-admin expects the ids of the deleted rows
   // but only the count is returned from prisma deleteMany method, so...
-  res.json({ data: ids });
+  const response = { data: ids };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/getListHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getListHandler.ts
@@ -92,8 +92,10 @@ export const getListHandler = async <Args extends GetListArgs>(
   await options?.transform?.(data);
 
   // RESPOND WITH DATA
-  res.json({
+  const response = {
     data,
     total,
-  });
+  };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/getManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getManyHandler.ts
@@ -28,5 +28,7 @@ export const getManyHandler = async <Args extends GetManyArgs>(
   // TRANSFORM
   await options?.transform?.(data);
 
-  res.json({ data });
+  const response = { data };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/getManyReferenceHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getManyReferenceHandler.ts
@@ -45,5 +45,7 @@ export const getManyReferenceHandler = async <Args extends GetManyRefernceArgs>(
   // TRANSFORM
   await options?.transform?.(data);
 
-  res.json({ data, total: data.length });
+  const response = { data, total: data.length };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/getOneHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getOneHandler.ts
@@ -35,5 +35,7 @@ export const getOneHandler = async <Args extends GetOneArgs>(
 
   if (options?.debug) console.log("getOneHandler:afterTransform", row);
 
-  res.json({ data: row });
+  const response = { data: row };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/updateHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateHandler.ts
@@ -199,5 +199,7 @@ export const updateHandler = async <Args extends UpdateArgs>(
     await auditHandler(req, options?.audit);
   }
 
-  res.json({ data: updated });
+  const response = { data: updated };
+  res.json(response);
+  return response;
 };

--- a/packages/ra-data-simple-prisma/src/updateManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateManyHandler.ts
@@ -1,4 +1,4 @@
-import { Response, UpdateManyRequest, UpdateRequest } from "./Http";
+import { Response, UpdateManyRequest } from "./Http";
 import { auditHandler } from "./audit/auditHandler";
 import { reduceData, UpdateArgs, UpdateOptions } from "./updateHandler";
 
@@ -26,5 +26,7 @@ export const updateManyHandler = async <Args extends UpdateArgs>(
   }
 
   //react-admin expects a array of ids as response
-  res.json({ data: ids });
+  const response = { data: ids };
+  res.json(response);
+  return response;
 };


### PR DESCRIPTION
While writing some custom handlers for specific resources that need manipulations to happen before sending it to the handler, or events that need to happen after a new item was created for example, I noticed that the handlers that [ra-data-simple-prisma](https://github.com/codeledge/ra-data-simple-prisma) exposes do not return any values, they just place them on the response.
This means you cannot access the just created row for example after executing the create handler.

This PR only changes that fact so that all handlers also return the data from the method that they put on the response so that you can more easily write custom handlers with side-effects.