### PR TITLE
Add link to video tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # React Admin & Prisma (& Next.js)
 
+[![react-admin-prisma-video](https://github.com/user-attachments/assets/2bb694a5-a70b-48c5-887c-208666f8aa99)](https://youtu.be/MMcRLwhmcIs?feature=shared)
+
 Check the example apps to see common usages or use them as a boilerplate.
 
 # Packages


### PR DESCRIPTION
The Prisma team has recorded a great demo video showing how to integrate Prisma and React-admin, using this package.

I think it'd be a great idea to feature the video in the readme.