### PR TITLE
feat: custom primaryKey support for models

### DIFF
--- a/packages/ra-data-simple-prisma/README.md
+++ b/packages/ra-data-simple-prisma/README.md
@@ -183,6 +183,7 @@ export default function handler(req) {
     case "delete":
       await deleteHandler<Prisma.PostDeleteArgs>(req.body, prismaClient, {
         softDeleteField: "deletedAt",
+        primaryKey: ... // defaults to "id"
         audit: ...
         debug: ...
       });
@@ -190,6 +191,7 @@ export default function handler(req) {
     case "deleteMany":
       await deleteManyHandler<Prisma.PostDeleteManyArgs>(req.body, prismaClient, {
         softDeleteField: "deletedAt",
+        primaryKey: ... // defaults to "id"
         audit: ...
         debug: ...
       });
@@ -213,7 +215,7 @@ export default function handler(req) {
           },
         }
       );
-      // OR, if using InfiniteList compoenent
+      // OR, if using InfiniteList component
       await getInfiniteListHandler<Prisma.PostFindManyArgs>(
         req.body,
         prismaClient,
@@ -237,6 +239,9 @@ export default function handler(req) {
       await getManyHandler<Prisma.PostFindManyArgs>(
         req.body,
         prismaClient,
+        {
+          primaryKey: ... // defaults to "id"
+        }
       );
       break;
     case "getManyReference":
@@ -250,6 +255,7 @@ export default function handler(req) {
         req.body,
         prismaClient,
         {
+          primaryKey: ... // defaults to "id"
           select: ...
           include: ...
           transform: (post: any) => {
@@ -271,6 +277,7 @@ export default function handler(req) {
         req.body,
         prismaClient,
         {
+          primaryKey: ... // defaults to "id", also used by updateMany
           skipFields: {
             computedField: true
           },
@@ -318,6 +325,27 @@ export default function handler(req) {
       break;
   }
 }
+```
+
+### Custom Primary Key
+
+By default all handlers use `id` as the primary key field, matching the react-admin data connector convention. If your Prisma model uses a different primary key name (e.g. `Id`, `StatusId`, `postId`) you can configure it per-handler via the `primaryKey` option.
+
+This affects how the `WHERE` clause is built for single-record lookups and multi-record `{ in: ids }` filters.
+
+```ts
+// /api/status.ts — model with a non-standard primary key "StatusId"
+
+case "getOne":
+  return getOneHandler(req.body, prismaClient, {
+    primaryKey: "StatusId",
+  });
+
+case "getMany":
+  return getManyHandler(req.body, prismaClient, {
+    primaryKey: "StatusId",
+  });
+...
 ```
 
 ### Helpers

--- a/packages/ra-data-simple-prisma/src/deleteHandler.ts
+++ b/packages/ra-data-simple-prisma/src/deleteHandler.ts
@@ -1,13 +1,14 @@
-import { AuditOptions } from "./audit/types";
-import { DeleteRequest } from "./Http";
 import { auditHandler } from "./audit/auditHandler";
+import { AuditOptions } from "./audit/types";
 import { getModel } from "./getModel";
+import { DeleteRequest } from "./Http";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type DeleteOptions = {
   softDeleteField?: string;
   debug?: boolean;
   audit?: AuditOptions;
+  primaryKey?: string;
 };
 
 // NOTE: generic type W is not used in this function yet
@@ -17,24 +18,25 @@ export const deleteHandler = async <
     include?: object | null;
     select?: object | null;
     where?: object | null;
-  }
+  },
 >(
   req: DeleteRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: DeleteOptions
+  options?: DeleteOptions,
 ) => {
   const model = getModel(req, prismaClient);
   const { id } = req.params;
+  const primaryKey = options?.primaryKey ?? "id";
 
   const deleted = options?.softDeleteField
     ? await model.update({
-        where: { id },
+        where: { [primaryKey]: id },
         data: {
           [options.softDeleteField]: new Date(),
         },
       })
     : await model.delete({
-        where: { id },
+        where: { [primaryKey]: id },
       });
 
   if (options?.audit) {

--- a/packages/ra-data-simple-prisma/src/deleteManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/deleteManyHandler.ts
@@ -1,32 +1,34 @@
-import { AuditOptions } from "./audit/types";
-import { DeleteManyRequest } from "./Http";
 import { auditHandler } from "./audit/auditHandler";
+import { AuditOptions } from "./audit/types";
 import { getModel } from "./getModel";
+import { DeleteManyRequest } from "./Http";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type DeleteManyOptions = {
   softDeleteField?: string;
   audit?: AuditOptions;
   debug?: boolean;
+  primaryKey?: string;
 };
 
 export const deleteManyHandler = async (
   req: DeleteManyRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: DeleteManyOptions
+  options?: DeleteManyOptions,
 ) => {
   const { ids } = req.params;
+  const primaryKey = options?.primaryKey ?? "id";
   const model = getModel(req, prismaClient);
 
   const deleted = options?.softDeleteField
     ? await model.updateMany({
-        where: { id: { in: ids } },
+        where: { [primaryKey]: { in: ids } },
         data: {
           [options?.softDeleteField]: new Date(),
         },
       })
     : await model.deleteMany({
-        where: { id: { in: ids } },
+        where: { [primaryKey]: { in: ids } },
       });
 
   if (options?.audit) {

--- a/packages/ra-data-simple-prisma/src/getManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getManyHandler.ts
@@ -1,5 +1,5 @@
-import { GetManyRequest } from "./Http";
 import { getModel } from "./getModel";
+import { GetManyRequest } from "./Http";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type GetManyArgs = {
@@ -9,28 +9,29 @@ export type GetManyArgs = {
 
 export type GetManyOptions<Args extends GetManyArgs = GetManyArgs> = Args & {
   debug?: boolean;
+  primaryKey?: string;
   transformRow?: (data: any) => any | Promise<any>;
 };
 
 export const getManyHandler = async <Args extends GetManyArgs>(
   req: GetManyRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: GetManyOptions<Args>
+  options?: GetManyOptions<Args>,
 ) => {
   const { ids } = req.params;
   const model = getModel(req, prismaClient);
+
+  const primaryKey = options?.primaryKey ?? "id";
 
   // GET DATA
   const rows = await model.findMany({
     include: options?.include,
     select: options?.select,
-    where: { id: { in: ids } },
+    where: { [primaryKey]: { in: ids } },
   });
 
   // TRANSFORM
-  const data = options?.transformRow
-    ? await Promise.all(rows.map(options.transformRow))
-    : rows;
+  const data = options?.transformRow ? await Promise.all(rows.map(options.transformRow)) : rows;
 
   const response = { data };
 

--- a/packages/ra-data-simple-prisma/src/getOneHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getOneHandler.ts
@@ -1,5 +1,5 @@
-import { GetOneRequest } from "./Http";
 import { getModel } from "./getModel";
+import { GetOneRequest } from "./Http";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type GetOneArgs = {
@@ -10,17 +10,19 @@ export type GetOneArgs = {
 
 export type GetOneOptions<Args extends GetOneArgs = GetOneArgs> = Args & {
   debug?: boolean;
+  primaryKey?: string;
   transform?: (row: any) => any | Promise<any>;
 };
 
 export const getOneHandler = async <Args extends GetOneArgs>(
   req: GetOneRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: GetOneOptions<Omit<Args, "where">> // omit where so the Prisma.ModelFindUniqueArgs can be passed in, without complaining about the where property missing
+  options?: GetOneOptions<Omit<Args, "where">>, // omit where so the Prisma.ModelFindUniqueArgs can be passed in, without complaining about the where property missing
 ) => {
   const { id } = req.params;
+  const primaryKey = options?.primaryKey ?? "id";
   const model = getModel(req, prismaClient);
-  const where = { id };
+  const where = { [primaryKey]: id };
 
   if (options?.debug) console.log("getOneHandler:where", where);
 
@@ -33,12 +35,9 @@ export const getOneHandler = async <Args extends GetOneArgs>(
   // TRANSFORM STAGE
   if (options?.debug) console.log("getOneHandler:beforeTransform", row);
 
-  const transformedRow = options?.transform
-    ? await options.transform(row)
-    : row;
+  const transformedRow = options?.transform ? await options.transform(row) : row;
 
-  if (options?.debug)
-    console.log("getOneHandler:afterTransform", transformedRow);
+  if (options?.debug) console.log("getOneHandler:afterTransform", transformedRow);
 
   // RESPONSE STAGE
   const response = { data: transformedRow };

--- a/packages/ra-data-simple-prisma/src/updateHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateHandler.ts
@@ -1,10 +1,10 @@
-import { AuditOptions } from "./audit/types";
-import { UpdateRequest } from "./Http";
-import { auditHandler } from "./audit/auditHandler";
-import { isNotField } from "./lib/isNotField";
 import { firstKey, firstValue, isObject, isString } from "deverything";
-import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
+import { auditHandler } from "./audit/auditHandler";
+import { AuditOptions } from "./audit/types";
 import { getModel } from "./getModel";
+import { UpdateRequest } from "./Http";
+import { isNotField } from "./lib/isNotField";
+import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type UpdateArgs = {
   include?: object | null;
@@ -59,6 +59,7 @@ export type UpdateOptions<Args extends UpdateArgs = UpdateArgs> = Args & {
     [key: string]: boolean;
   };
   audit?: AuditOptions;
+  primaryKey?: string;
 };
 
 export const reduceData = (data, options: UpdateOptions) => {
@@ -183,9 +184,10 @@ export const reduceData = (data, options: UpdateOptions) => {
 export const updateHandler = async <Args extends UpdateArgs>(
   req: UpdateRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: UpdateOptions<Omit<Args, "data" | "where">>
+  options?: UpdateOptions<Omit<Args, "data" | "where">>,
 ) => {
   const { id } = req.params;
+  const primaryKey = options?.primaryKey ?? "id";
   const model = getModel(req, prismaClient);
   const data = reduceData(req.params.data, options);
 
@@ -197,7 +199,7 @@ export const updateHandler = async <Args extends UpdateArgs>(
     data,
     include: options?.include ?? undefined,
     select: options?.select ?? undefined,
-    where: { id },
+    where: { [primaryKey]: id },
   });
 
   if (options?.audit) {

--- a/packages/ra-data-simple-prisma/src/updateManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateManyHandler.ts
@@ -1,15 +1,16 @@
-import { UpdateManyRequest } from "./Http";
 import { auditHandler } from "./audit/auditHandler";
-import { reduceData, UpdateArgs, UpdateOptions } from "./updateHandler";
-import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 import { getModel } from "./getModel";
+import { UpdateManyRequest } from "./Http";
+import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
+import { reduceData, UpdateArgs, UpdateOptions } from "./updateHandler";
 
 export const updateManyHandler = async <Args extends UpdateArgs>(
   req: UpdateManyRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: Omit<UpdateOptions<Args>, "select" | "include">
+  options?: Omit<UpdateOptions<Args>, "select" | "include">,
 ) => {
   const { ids } = req.params;
+  const primaryKey = options?.primaryKey ?? "id";
   const model = getModel(req, prismaClient);
   const data = reduceData(req.params.data, options);
 
@@ -19,7 +20,7 @@ export const updateManyHandler = async <Args extends UpdateArgs>(
 
   await model.updateMany({
     data,
-    where: { id: { in: ids } },
+    where: { [primaryKey]: { in: ids } },
   });
 
   if (options?.audit) {

--- a/packages/ra-data-simple-prisma/tests/primaryKey.test.ts
+++ b/packages/ra-data-simple-prisma/tests/primaryKey.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { deleteHandler } from "../src/deleteHandler";
+import { deleteManyHandler } from "../src/deleteManyHandler";
+import { getManyHandler } from "../src/getManyHandler";
+import { getOneHandler } from "../src/getOneHandler";
+import type { PrismaClientOrDynamicClientExtension } from "../src/PrismaClientTypes";
+import { updateHandler } from "../src/updateHandler";
+import { updateManyHandler } from "../src/updateManyHandler";
+
+/** Build a minimal mock Prisma model and return it alongside the client stub. */
+function makeMockModel() {
+  const model = {
+    findMany: jest.fn().mockResolvedValue([] as never),
+    findUnique: jest.fn().mockResolvedValue({ IrregularPrimaryKeyId: 42, name: "row" } as never),
+    create: jest.fn().mockResolvedValue({ IrregularPrimaryKeyId: 42 } as never),
+    update: jest.fn().mockResolvedValue({ IrregularPrimaryKeyId: 42 } as never),
+    updateMany: jest.fn().mockResolvedValue({ count: 2 } as never),
+    delete: jest.fn().mockResolvedValue({ IrregularPrimaryKeyId: 42 } as never),
+    deleteMany: jest.fn().mockResolvedValue({ count: 2 } as never),
+  };
+
+  const prismaClient = {
+    post: model,
+  } as unknown as PrismaClientOrDynamicClientExtension;
+
+  return { model, prismaClient };
+}
+
+// ─── getManyHandler ───────────────────────────────────────────────────────────
+
+describe("getManyHandler - primaryKey", () => {
+  let model: ReturnType<typeof makeMockModel>["model"];
+  let prismaClient: PrismaClientOrDynamicClientExtension;
+
+  beforeEach(() => {
+    ({ model, prismaClient } = makeMockModel());
+  });
+
+  test("defaults to `id` when no primaryKey option is given", async () => {
+    await getManyHandler({ method: "getMany", resource: "post", params: { ids: [1, 2] } }, prismaClient);
+    expect(model.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: { in: [1, 2] } } }));
+  });
+
+  test("uses a custom primaryKey in the WHERE clause", async () => {
+    await getManyHandler({ method: "getMany", resource: "post", params: { ids: [1, 2] } }, prismaClient, {
+      primaryKey: "IrregularPrimaryKeyId",
+    });
+    expect(model.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { IrregularPrimaryKeyId: { in: [1, 2] } } }),
+    );
+  });
+});
+
+// ─── getOneHandler ────────────────────────────────────────────────────────────
+
+describe("getOneHandler - primaryKey", () => {
+  let model: ReturnType<typeof makeMockModel>["model"];
+  let prismaClient: PrismaClientOrDynamicClientExtension;
+
+  beforeEach(() => {
+    ({ model, prismaClient } = makeMockModel());
+  });
+
+  test("defaults to `id` when no primaryKey option is given", async () => {
+    await getOneHandler({ method: "getOne", resource: "post", params: { id: 42 } }, prismaClient);
+    expect(model.findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 42 } }));
+  });
+
+  test("uses a custom primaryKey in the WHERE clause", async () => {
+    await getOneHandler({ method: "getOne", resource: "post", params: { id: 42 } }, prismaClient, {
+      primaryKey: "IrregularPrimaryKeyId",
+    });
+    expect(model.findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { IrregularPrimaryKeyId: 42 } }));
+  });
+});
+
+// ─── deleteHandler ────────────────────────────────────────────────────────────
+
+describe("deleteHandler - primaryKey", () => {
+  let model: ReturnType<typeof makeMockModel>["model"];
+  let prismaClient: PrismaClientOrDynamicClientExtension;
+
+  beforeEach(() => {
+    ({ model, prismaClient } = makeMockModel());
+  });
+
+  test("defaults to `id` when no primaryKey option is given", async () => {
+    await deleteHandler(
+      {
+        method: "delete",
+        resource: "post",
+        params: { id: 42, previousData: { id: 42 } },
+      },
+      prismaClient,
+    );
+    expect(model.delete).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 42 } }));
+  });
+
+  test("uses a custom primaryKey in the WHERE clause", async () => {
+    await deleteHandler(
+      {
+        method: "delete",
+        resource: "post",
+        params: { id: 42, previousData: { id: 42 } },
+      },
+      prismaClient,
+      { primaryKey: "IrregularPrimaryKeyId" },
+    );
+    expect(model.delete).toHaveBeenCalledWith(expect.objectContaining({ where: { IrregularPrimaryKeyId: 42 } }));
+  });
+
+  test("uses a custom primaryKey with softDeleteField", async () => {
+    await deleteHandler(
+      {
+        method: "delete",
+        resource: "post",
+        params: { id: 42, previousData: { id: 42 } },
+      },
+      prismaClient,
+      { primaryKey: "IrregularPrimaryKeyId", softDeleteField: "deletedAt" },
+    );
+    expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ where: { IrregularPrimaryKeyId: 42 } }));
+  });
+});
+
+// ─── deleteManyHandler ────────────────────────────────────────────────────────
+
+describe("deleteManyHandler - primaryKey", () => {
+  let model: ReturnType<typeof makeMockModel>["model"];
+  let prismaClient: PrismaClientOrDynamicClientExtension;
+
+  beforeEach(() => {
+    ({ model, prismaClient } = makeMockModel());
+  });
+
+  test("defaults to `id` when no primaryKey option is given", async () => {
+    await deleteManyHandler({ method: "deleteMany", resource: "post", params: { ids: [1, 2] } }, prismaClient);
+    expect(model.deleteMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: { in: [1, 2] } } }));
+  });
+
+  test("uses a custom primaryKey in the WHERE clause", async () => {
+    await deleteManyHandler({ method: "deleteMany", resource: "post", params: { ids: [1, 2] } }, prismaClient, {
+      primaryKey: "IrregularPrimaryKeyId",
+    });
+    expect(model.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { IrregularPrimaryKeyId: { in: [1, 2] } } }),
+    );
+  });
+
+  test("uses a custom primaryKey with softDeleteField", async () => {
+    await deleteManyHandler({ method: "deleteMany", resource: "post", params: { ids: [1, 2] } }, prismaClient, {
+      primaryKey: "IrregularPrimaryKeyId",
+      softDeleteField: "deletedAt",
+    });
+    expect(model.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { IrregularPrimaryKeyId: { in: [1, 2] } } }),
+    );
+  });
+});
+
+// ─── updateHandler ────────────────────────────────────────────────────────────
+
+describe("updateHandler - primaryKey", () => {
+  let model: ReturnType<typeof makeMockModel>["model"];
+  let prismaClient: PrismaClientOrDynamicClientExtension;
+
+  beforeEach(() => {
+    ({ model, prismaClient } = makeMockModel());
+  });
+
+  test("defaults to `id` when no primaryKey option is given", async () => {
+    await updateHandler(
+      {
+        method: "update",
+        resource: "post",
+        params: { id: 42, data: { name: "updated" }, previousData: { id: 42 } },
+      },
+      prismaClient,
+    );
+    expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 42 } }));
+  });
+
+  test("uses a custom primaryKey in the WHERE clause", async () => {
+    await updateHandler(
+      {
+        method: "update",
+        resource: "post",
+        params: { id: 42, data: { name: "updated" }, previousData: { id: 42 } },
+      },
+      prismaClient,
+      { primaryKey: "IrregularPrimaryKeyId" },
+    );
+    expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ where: { IrregularPrimaryKeyId: 42 } }));
+  });
+});
+
+// ─── updateManyHandler ────────────────────────────────────────────────────────
+
+describe("updateManyHandler - primaryKey", () => {
+  let model: ReturnType<typeof makeMockModel>["model"];
+  let prismaClient: PrismaClientOrDynamicClientExtension;
+
+  beforeEach(() => {
+    ({ model, prismaClient } = makeMockModel());
+  });
+
+  test("defaults to `id` when no primaryKey option is given", async () => {
+    await updateManyHandler(
+      {
+        method: "updateMany",
+        resource: "post",
+        params: { ids: [1, 2], data: { published: true } },
+      },
+      prismaClient,
+    );
+    expect(model.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: { in: [1, 2] } } }));
+  });
+
+  test("uses a custom primaryKey in the WHERE clause", async () => {
+    await updateManyHandler(
+      {
+        method: "updateMany",
+        resource: "post",
+        params: { ids: [1, 2], data: { published: true } },
+      },
+      prismaClient,
+      { primaryKey: "IrregularPrimaryKeyId" },
+    );
+    expect(model.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { IrregularPrimaryKeyId: { in: [1, 2] } } }),
+    );
+  });
+});


### PR DESCRIPTION
By default all handlers use `id` as the primary key field, matching the react-admin data connector convention. If your Prisma model uses a different primary key name (e.g. `Id`, `StatusId`, `postId`) you can configure it per-handler via the `primaryKey` option.