### PR TITLE
allowOnlyFields support for createHandler

### DIFF
--- a/apps/admin/app/api/post/route.ts
+++ b/apps/admin/app/api/post/route.ts
@@ -37,6 +37,7 @@ const route = apiHandler(async (raPayload, { sessionAuthProvider }) => {
         raPayload,
         prismaClient,
         {
+          // allowOnlyFields: { title: true, body: true, tagIds: true, mediaIds: true },
           connect: {
             //tags: "id", if the prop is tag: [1,2,3]
             tagIds: {
@@ -90,6 +91,7 @@ const route = apiHandler(async (raPayload, { sessionAuthProvider }) => {
         raPayload,
         prismaClient,
         {
+          // allowOnlyFields: { title: true, body: true, tagIds: true, mediaIds: true },
           set: {
             //tags: "id", if the prop is tag: [1,2,3]
             tagIds: {

--- a/packages/ra-data-simple-prisma/README.md
+++ b/packages/ra-data-simple-prisma/README.md
@@ -163,6 +163,11 @@ export default function handler(req) {
   switch (req.body.method) {
     case "create":
       await createHandler<Prisma.PostCreateArgs>(req.body, prismaClient, {
+        allowOnlyFields: {
+          title: true,
+          body: true,
+          tagIds: true,
+        },
         connect: {
           tags: "id",
           // or
@@ -278,6 +283,11 @@ export default function handler(req) {
         prismaClient,
         {
           primaryKey: ... // defaults to "id", also used by updateMany
+          allowOnlyFields: {
+            title: true,
+            body: true,
+            tagIds: true,
+          },
           skipFields: {
             computedField: true
           },
@@ -347,6 +357,32 @@ case "getMany":
   });
 ...
 ```
+
+### Allow Only Fields
+
+Both `createHandler` and `updateHandler` support an `allowOnlyFields` option that acts as an explicit allow-list of fields that may be written.
+
+```ts
+// create
+await createHandler(req.body, prismaClient, {
+  allowOnlyFields: {
+    title: true,
+    body: true,
+    tagIds: true,
+  },
+});
+
+// update
+await updateHandler(req.body, prismaClient, {
+  allowOnlyFields: {
+    title: true,
+    body: true,
+    tagIds: true,
+  },
+});
+```
+
+> **Note:** Fields with an empty string value (`""`) and internal `_`-prefixed fields (e.g. `_count`) are stripped automatically before the allow-list is checked, so they will never trigger an error.
 
 ### Helpers
 

--- a/packages/ra-data-simple-prisma/src/createHandler.ts
+++ b/packages/ra-data-simple-prisma/src/createHandler.ts
@@ -1,46 +1,23 @@
-import { AuditOptions } from "./audit/types";
-import { CreateRequest } from "./Http";
-import { auditHandler } from "./audit/auditHandler";
-import { isNotField } from "./lib/isNotField";
 import { firstKey, firstValue, isObject, isString } from "deverything";
+import { auditHandler } from "./audit/auditHandler";
+import type { AuditOptions } from "./audit/types";
 import { getModel } from "./getModel";
-import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
+import type { CreateRequest } from "./Http";
+import { isNotField } from "./lib/isNotField";
+import type { SetExplicitConnection, SetImplicitConnection, SetImplicitShortcut } from "./lib/types";
+import type { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type CreateArgs = {
   include?: object | null;
   select?: object | null;
 };
 
-// export type CreateImplicitConnectionShortcut = {
-//   [key: string]: string;
-// };
-
-// export type CreateImplicitConnection = {
-//   [key: string]: {
-//     [key: string]: string;
-//   };
-// };
-
-// export type CreateExplicitConnection = {
-//   [key: string]: {
-//     [key: string]: {
-//       [key: string]: string;
-//     };
-//   };
-// };
-
 export type CreateOptions<Args extends CreateArgs = CreateArgs> = Args & {
+  allowOnlyFields?: {
+    [key: string]: boolean;
+  };
   connect?: {
-    // TODO: Make this work CreateImplicitConnectionShortcut | CreateImplicitConnection | CreateExplicitConnection;
-    [key: string]:
-      | string
-      | {
-          [key: string]:
-            | string
-            | {
-                [key: string]: string;
-              };
-        };
+    [key: string]: SetImplicitShortcut | SetImplicitConnection | SetExplicitConnection;
   };
   audit?: AuditOptions;
   debug?: boolean;
@@ -49,7 +26,7 @@ export type CreateOptions<Args extends CreateArgs = CreateArgs> = Args & {
 export const createHandler = async <Args extends CreateArgs>(
   req: CreateRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: CreateOptions<Omit<Args, "data">> // omit data so the Prisma.ModelCreateArgs can be passed in, without complaining about the data property missing
+  options?: CreateOptions<Omit<Args, "data">>, // omit data so the Prisma.ModelCreateArgs can be passed in, without complaining about the data property missing
 ) => {
   const model = getModel(req, prismaClient);
   const { data } = req.params;
@@ -60,9 +37,14 @@ export const createHandler = async <Args extends CreateArgs>(
   Object.entries(data).forEach(([key, value]) => {
     if (value === "") {
       delete data[key];
+      return;
     }
     if (isNotField(key)) {
       delete data[key];
+      return;
+    }
+    if (options?.allowOnlyFields && !options.allowOnlyFields[key]) {
+      throw new Error(`createHandler: Field ${key} is not allowed in create`);
     }
   });
 
@@ -80,9 +62,7 @@ export const createHandler = async <Args extends CreateArgs>(
       //    });
       // (data) tags: [1, 2, 3] => tags: { connect: [{id: 1}, {id: 2}, {id: 3}] }
       data[prop] = {
-        connect: Array.isArray(value)
-          ? value.map((key) => ({ [foreignConnect]: key }))
-          : { [foreignConnect]: value },
+        connect: Array.isArray(value) ? value.map((key) => ({ [foreignConnect]: key })) : { [foreignConnect]: value },
       };
 
       // in theory no need to remove the original data

--- a/packages/ra-data-simple-prisma/src/lib/types.ts
+++ b/packages/ra-data-simple-prisma/src/lib/types.ts
@@ -1,0 +1,11 @@
+export type SetImplicitShortcut = string;
+
+export type SetImplicitConnection = {
+  [connectModel: string]: string;
+};
+
+export type SetExplicitConnection = {
+  [pivotModel: string]: {
+    [connectModel: string]: string;
+  };
+};

--- a/packages/ra-data-simple-prisma/src/updateHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateHandler.ts
@@ -1,33 +1,27 @@
 import { firstKey, firstValue, isObject, isString } from "deverything";
 import { auditHandler } from "./audit/auditHandler";
-import { AuditOptions } from "./audit/types";
+import type { AuditOptions } from "./audit/types";
 import { getModel } from "./getModel";
-import { UpdateRequest } from "./Http";
+import type { UpdateRequest } from "./Http";
 import { isNotField } from "./lib/isNotField";
-import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
+import type { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type UpdateArgs = {
   include?: object | null;
   select?: object | null;
 };
 
-// export type UpdateImplicitConnectionShortcut = {
-//   [key: string]: string;
-// };
+export type SetImplicitShortcut = string;
 
-// export type UpdateImplicitConnection = {
-//   [key: string]: {
-//     [key: string]: string;
-//   };
-// };
+export type SetImplicitConnection = {
+  [connectModel: string]: string;
+};
 
-// export type CreateExplicitConnection = {
-//   [key: string]: {
-//     [key: string]: {
-//       [key: string]: string;
-//     };
-//   };
-// };
+export type SetExplicitConnection = {
+  [pivotModel: string]: {
+    [connectModel: string]: string;
+  };
+};
 
 export type UpdateOptions<Args extends UpdateArgs = UpdateArgs> = Args & {
   debug?: boolean;
@@ -38,16 +32,7 @@ export type UpdateOptions<Args extends UpdateArgs = UpdateArgs> = Args & {
     [key: string]: boolean;
   };
   set?: {
-    // TODO: Make this work UpdateImplicitConnectionShortcut | UpdateImplicitConnection | CreateExplicitConnection;
-    [key: string]:
-      | string
-      | {
-          [key: string]:
-            | string
-            | {
-                [key: string]: string;
-              };
-        };
+    [key: string]: SetImplicitShortcut | SetImplicitConnection | SetExplicitConnection;
   };
   allowNestedUpdate?: {
     [key: string]: boolean;

--- a/packages/ra-data-simple-prisma/src/updateHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateHandler.ts
@@ -4,23 +4,14 @@ import type { AuditOptions } from "./audit/types";
 import { getModel } from "./getModel";
 import type { UpdateRequest } from "./Http";
 import { isNotField } from "./lib/isNotField";
+import type { SetExplicitConnection, SetImplicitConnection, SetImplicitShortcut } from "./lib/types";
 import type { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
+
+export type { SetExplicitConnection, SetImplicitConnection, SetImplicitShortcut };
 
 export type UpdateArgs = {
   include?: object | null;
   select?: object | null;
-};
-
-export type SetImplicitShortcut = string;
-
-export type SetImplicitConnection = {
-  [connectModel: string]: string;
-};
-
-export type SetExplicitConnection = {
-  [pivotModel: string]: {
-    [connectModel: string]: string;
-  };
 };
 
 export type UpdateOptions<Args extends UpdateArgs = UpdateArgs> = Args & {

--- a/packages/ra-data-simple-prisma/tests/createHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/createHandler.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { createHandler } from "../src/createHandler";
+import type { CreateRequest } from "../src/Http";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock("../src/getModel");
+jest.mock("../src/audit/auditHandler");
+
+import { auditHandler } from "../src/audit/auditHandler";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockAuditHandler = auditHandler as jest.MockedFunction<typeof auditHandler>;
+
+function makeReq(data: Record<string, unknown>, resource = "post"): CreateRequest {
+  return {
+    method: "create",
+    resource,
+    params: { data },
+  };
+}
+
+function makeMockModel() {
+  return {
+    create: jest.fn().mockResolvedValue({ id: 1, title: "New Post" } as never),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Field filtering
+// ---------------------------------------------------------------------------
+
+describe("createHandler - field filtering", () => {
+  test("passes scalar fields through and returns { data: created }", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ title: "Hello", count: 5 });
+    const result = await createHandler(req, {} as never);
+
+    expect(model.create).toHaveBeenCalledWith(expect.objectContaining({ data: { title: "Hello", count: 5 } }));
+    expect(result).toEqual({ data: { id: 1, title: "New Post" } });
+  });
+
+  test("removes empty string fields before creating", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ title: "Keep", subtitle: "" });
+    await createHandler(req, {} as never);
+
+    expect(model.create).toHaveBeenCalledWith(expect.objectContaining({ data: { title: "Keep" } }));
+  });
+
+  test("removes _ prefixed fields (isNotField)", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ title: "Hi", _count: 3, _sum: 10 });
+    await createHandler(req, {} as never);
+
+    expect(model.create).toHaveBeenCalledWith(expect.objectContaining({ data: { title: "Hi" } }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allowOnlyFields
+// ---------------------------------------------------------------------------
+
+describe("createHandler - allowOnlyFields", () => {
+  test("keeps permitted fields", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ title: "Hi", safe: "yes" });
+    await createHandler(req, {} as never, { allowOnlyFields: { title: true, safe: true } });
+
+    expect(model.create).toHaveBeenCalledWith(expect.objectContaining({ data: { title: "Hi", safe: "yes" } }));
+  });
+
+  test("throws for a field not in the allow list", async () => {
+    mockGetModel.mockReturnValue(makeMockModel() as never);
+
+    const req = makeReq({ title: "Hi", extra: "bad" });
+    await expect(createHandler(req, {} as never, { allowOnlyFields: { title: true } })).rejects.toThrow(
+      "createHandler: Field extra is not allowed in create",
+    );
+  });
+
+  test("empty string fields are removed before allowOnlyFields is checked", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    // "extra" would fail allowOnlyFields, but it has an empty value so it is removed first
+    const req = makeReq({ title: "Hi", extra: "" });
+    await expect(createHandler(req, {} as never, { allowOnlyFields: { title: true } })).resolves.toBeDefined();
+  });
+
+  test("_ prefixed fields are removed before allowOnlyFields is checked", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ title: "Hi", _count: 3 });
+    await expect(createHandler(req, {} as never, { allowOnlyFields: { title: true } })).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connect option
+// ---------------------------------------------------------------------------
+
+describe("createHandler - connect option", () => {
+  // implicit shortcut: connect: { tags: "id" }
+  test("string shortcut maps array to { connect: [{id},...] }", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ tags: [1, 2, 3] });
+    await createHandler(req, {} as never, { connect: { tags: "id" } });
+
+    expect(model.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { tags: { connect: [{ id: 1 }, { id: 2 }, { id: 3 }] } },
+      }),
+    );
+  });
+
+  test("string shortcut maps single value to { connect: {id} }", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ category: 5 });
+    await createHandler(req, {} as never, { connect: { category: "id" } });
+
+    expect(model.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { category: { connect: { id: 5 } } },
+      }),
+    );
+  });
+
+  // implicit object connection: connect: { tagIds: { tags: "id" } }
+  test("implicit object connection maps tagIds to tags.connect, removes tagIds", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ tagIds: [10, 20] });
+    await createHandler(req, {} as never, { connect: { tagIds: { tags: "id" } } });
+
+    const callData = (model.create.mock.calls[0] as [{ data: unknown }])[0].data;
+    expect(callData).toEqual({
+      tags: { connect: [{ id: 10 }, { id: 20 }] },
+    });
+    expect(callData).not.toHaveProperty("tagIds");
+  });
+
+  // explicit connection: connect: { mediaIds: { postToMediaRels: { media: "id" } } }
+  test("explicit object connection builds create array and removes original key", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq({ mediaIds: [5, 6] });
+    await createHandler(req, {} as never, {
+      connect: { mediaIds: { postToMediaRels: { media: "id" } } },
+    });
+
+    const callData = (model.create.mock.calls[0] as [{ data: unknown }])[0].data;
+    expect(callData).toEqual({
+      postToMediaRels: {
+        create: [{ media: { connect: { id: 5 } } }, { media: { connect: { id: 6 } } }],
+      },
+    });
+    expect(callData).not.toHaveProperty("mediaIds");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// options forwarded to model.create
+// ---------------------------------------------------------------------------
+
+describe("createHandler - model options", () => {
+  test("passes include to model.create", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await createHandler(makeReq({ title: "Hi" }), {} as never, { include: { tags: true } });
+
+    expect(model.create).toHaveBeenCalledWith(expect.objectContaining({ include: { tags: true } }));
+  });
+
+  test("passes select to model.create", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await createHandler(makeReq({ title: "Hi" }), {} as never, { select: { id: true, title: true } });
+
+    expect(model.create).toHaveBeenCalledWith(expect.objectContaining({ select: { id: true, title: true } }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// debug
+// ---------------------------------------------------------------------------
+
+describe("createHandler - debug", () => {
+  test("debug logs data before and after create", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await createHandler(makeReq({ title: "Debug" }), {} as never, { debug: true });
+
+    expect(consoleSpy).toHaveBeenCalledWith("createHandler:data", { title: "Debug" });
+    expect(consoleSpy).toHaveBeenCalledWith("createHandler:created", { id: 1, title: "New Post" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// audit
+// ---------------------------------------------------------------------------
+
+describe("createHandler - audit", () => {
+  test("calls auditHandler with req, options, and created record", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockAuditHandler.mockResolvedValue(undefined as never);
+
+    const auditOptions = {
+      model: { create: jest.fn() },
+      authProvider: {} as never,
+    };
+    const req = makeReq({ title: "Audited" });
+    await createHandler(req, {} as never, { audit: auditOptions });
+
+    expect(mockAuditHandler).toHaveBeenCalledWith(req, auditOptions, { id: 1, title: "New Post" });
+  });
+
+  test("does not call auditHandler when audit option is absent", async () => {
+    mockGetModel.mockReturnValue(makeMockModel() as never);
+
+    await createHandler(makeReq({ title: "No audit" }), {} as never);
+
+    expect(mockAuditHandler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/updateHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/updateHandler.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import type { UpdateRequest } from "../src/Http";
+import { reduceData, updateHandler } from "../src/updateHandler";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock("../src/getModel");
+jest.mock("../src/audit/auditHandler");
+
+import { auditHandler } from "../src/audit/auditHandler";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockAuditHandler = auditHandler as jest.MockedFunction<typeof auditHandler>;
+
+function makeReq(id: string | number, data: Record<string, unknown>, resource = "post"): UpdateRequest {
+  return {
+    method: "update",
+    resource,
+    params: { id, data, previousData: {} },
+  };
+}
+
+function makeMockModel() {
+  return {
+    update: jest.fn().mockResolvedValue({ id: 1, title: "Post" } as never),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// reduceData — pure logic, no mocks needed
+// ---------------------------------------------------------------------------
+
+describe("reduceData", () => {
+  test("passes scalar fields through", () => {
+    const result = reduceData({ title: "Hello", count: 5 }, {});
+    expect(result).toEqual({ title: "Hello", count: 5 });
+  });
+
+  test("passes array fields through when no set option matches", () => {
+    const result = reduceData({ ids: [1, 2, 3] }, {});
+    expect(result).toEqual({ ids: [1, 2, 3] });
+  });
+
+  test("skips fields that start with _ (isNotField)", () => {
+    const result = reduceData({ title: "Hi", _count: 3, _sum: 10 }, {});
+    expect(result).toEqual({ title: "Hi" });
+  });
+
+  test("skipFields removes specified fields", () => {
+    const result = reduceData({ title: "Hi", secret: "s", other: "o" }, { skipFields: { secret: true } });
+    expect(result).toEqual({ title: "Hi", other: "o" });
+  });
+
+  test("allowOnlyFields keeps permitted fields", () => {
+    const result = reduceData({ title: "Hi", safe: "yes" }, { allowOnlyFields: { title: true, safe: true } });
+    expect(result).toEqual({ title: "Hi", safe: "yes" });
+  });
+
+  test("allowOnlyFields throws for a field not in the allow list", () => {
+    expect(() => reduceData({ title: "Hi", extra: "bad" }, { allowOnlyFields: { title: true } })).toThrow(
+      "updateHandler: Field extra is not allowed in update",
+    );
+  });
+
+  // set — implicit shortcut: set: { tags: "id" }
+  test("set with string (implicit shortcut) transforms array to { set: [{id},...] }", () => {
+    const result = reduceData({ tags: [1, 2, 3] }, { set: { tags: "id" } });
+    expect(result).toEqual({
+      tags: { set: [{ id: 1 }, { id: 2 }, { id: 3 }] },
+    });
+  });
+
+  // set — implicit connection: set: { tagIds: { tags: "id" } }
+  test("set with implicit object connection transforms tagIds to tags.set", () => {
+    const result = reduceData({ tagIds: [10, 20] }, { set: { tagIds: { tags: "id" } } });
+    expect(result).toEqual({
+      tags: { set: [{ id: 10 }, { id: 20 }] },
+    });
+    // Original key is removed
+    expect(result).not.toHaveProperty("tagIds");
+  });
+
+  // set — explicit connection: set: { mediaIds: { postToMediaRels: { media: "id" } } }
+  test("set with explicit object connection builds deleteMany + create", () => {
+    const result = reduceData({ mediaIds: [5, 6] }, { set: { mediaIds: { postToMediaRels: { media: "id" } } } });
+    expect(result).toEqual({
+      postToMediaRels: {
+        deleteMany: {},
+        create: [{ media: { connect: { id: 5 } } }, { media: { connect: { id: 6 } } }],
+      },
+    });
+    expect(result).not.toHaveProperty("mediaIds");
+  });
+
+  // allowNestedUpdate
+  test("allowNestedUpdate wraps object in { update: { data } }", () => {
+    const result = reduceData({ profile: { bio: "hello" } }, { allowNestedUpdate: { profile: true } });
+    expect(result).toEqual({
+      profile: { update: { data: { bio: "hello" } } },
+    });
+  });
+
+  // allowNestedUpsert
+  test("allowNestedUpsert wraps object in { upsert: { create, update } }", () => {
+    const result = reduceData({ profile: { bio: "hello" } }, { allowNestedUpsert: { profile: true } });
+    expect(result).toEqual({
+      profile: { upsert: { create: { bio: "hello" }, update: { bio: "hello" } } },
+    });
+  });
+
+  // allowJsonUpdate
+  test("allowJsonUpdate passes nested object through as-is", () => {
+    const meta = { key: "value", nested: { a: 1 } };
+    const result = reduceData({ meta }, { allowJsonUpdate: { meta: true } });
+    expect(result).toEqual({ meta });
+  });
+
+  test("object field with no nested option is omitted from result", () => {
+    const result = reduceData({ nested: { x: 1 } }, {});
+    expect(result).not.toHaveProperty("nested");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateHandler — integration with mocked getModel / auditHandler
+// ---------------------------------------------------------------------------
+
+describe("updateHandler", () => {
+  test("calls model.update with data and where { id }, returns { data }", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq(42, { title: "Updated" });
+    const result = await updateHandler(req, {} as never);
+
+    expect(model.update).toHaveBeenCalledWith({
+      data: { title: "Updated" },
+      include: undefined,
+      select: undefined,
+      where: { id: 42 },
+    });
+    expect(result).toEqual({ data: { id: 1, title: "Post" } });
+  });
+
+  test("passes include option to model.update", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq(1, { title: "Hi" });
+    await updateHandler(req, {} as never, { include: { comments: true } });
+
+    expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ include: { comments: true } }));
+  });
+
+  test("passes select option to model.update", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq(1, { title: "Hi" });
+    await updateHandler(req, {} as never, { select: { id: true, title: true } });
+
+    expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ select: { id: true, title: true } }));
+  });
+
+  test("debug option logs the reduced data", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const req = makeReq(1, { title: "Debug" });
+    await updateHandler(req, {} as never, { debug: true });
+
+    expect(consoleSpy).toHaveBeenCalledWith("updateHandler:data", {
+      title: "Debug",
+    });
+  });
+
+  test("audit option calls auditHandler", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockAuditHandler.mockResolvedValue(undefined as never);
+
+    const auditOptions = {
+      model: { create: jest.fn() },
+      authProvider: {} as never,
+    };
+    const req = makeReq(1, { title: "Audited" });
+    await updateHandler(req, {} as never, { audit: auditOptions });
+
+    expect(mockAuditHandler).toHaveBeenCalledWith(req, auditOptions);
+  });
+
+  test("does not call auditHandler when audit option is absent", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq(1, { title: "No audit" });
+    await updateHandler(req, {} as never);
+
+    expect(mockAuditHandler).not.toHaveBeenCalled();
+  });
+
+  test("applies reduceData transformations: skipFields", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq(1, { title: "Keep", secret: "drop" });
+    await updateHandler(req, {} as never, { skipFields: { secret: true } });
+
+    expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ data: { title: "Keep" } }));
+  });
+
+  test("applies reduceData transformations: set with string", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq(1, { tags: [1, 2] });
+    await updateHandler(req, {} as never, { set: { tags: "id" } });
+
+    expect(model.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { tags: { set: [{ id: 1 }, { id: 2 }] } },
+      }),
+    );
+  });
+
+  test("string id is forwarded as-is in where clause", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq("abc-123", { name: "Test" });
+    await updateHandler(req, {} as never);
+
+    expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "abc-123" } }));
+  });
+});


### PR DESCRIPTION
- Adds `allowOnlyFields` to `createHandler` (same as `updateHandler`)
- Adds tests for create and update handlers
- Implements connection types TODO