### PR TITLE
feat: ensure create, update and returned records are primary key normalized

### DIFF
--- a/packages/ra-data-simple-prisma/README.md
+++ b/packages/ra-data-simple-prisma/README.md
@@ -206,6 +206,7 @@ export default function handler(req) {
         req.body,
         prismaClient,
         {
+          primaryKey: ... // defaults to "id"
           select: ...
           where: ...
           noNullsOnSort: ...
@@ -225,6 +226,7 @@ export default function handler(req) {
         req.body,
         prismaClient,
         {
+          primaryKey: ... // defaults to "id"
           select: ...
           where: ...
           noNullsOnSort: ...
@@ -253,6 +255,9 @@ export default function handler(req) {
       await getManyReferenceHandler<Prisma.PostFindManyArgs>(
         req.body,
         prismaClient,
+        {
+          primaryKey: ... // defaults to "id"
+        }
       );
       break;
     case "getOne":
@@ -341,7 +346,10 @@ export default function handler(req) {
 
 By default all handlers use `id` as the primary key field, matching the react-admin data connector convention. If your Prisma model uses a different primary key name (e.g. `Id`, `StatusId`, `postId`) you can configure it per-handler via the `primaryKey` option.
 
-This affects how the `WHERE` clause is built for single-record lookups and multi-record `{ in: ids }` filters.
+This affects:
+
+- how the `WHERE` clause is built for single-record lookups and multi-record `{ in: ids }` filters
+- how incoming write payloads are handled and returned records are normalized for react-admin compatibility
 
 ```ts
 // /api/status.ts — model with a non-standard primary key "StatusId"

--- a/packages/ra-data-simple-prisma/src/createHandler.ts
+++ b/packages/ra-data-simple-prisma/src/createHandler.ts
@@ -21,6 +21,7 @@ export type CreateOptions<Args extends CreateArgs = CreateArgs> = Args & {
   };
   audit?: AuditOptions;
   debug?: boolean;
+  primaryKey?: string;
 };
 
 export const createHandler = async <Args extends CreateArgs>(
@@ -30,11 +31,17 @@ export const createHandler = async <Args extends CreateArgs>(
 ) => {
   const model = getModel(req, prismaClient);
   const { data } = req.params;
+  const primaryKey = options?.primaryKey ?? "id";
 
   if (options?.debug) console.log("createHandler:data", data);
 
   // Filter out invalid fields
   Object.entries(data).forEach(([key, value]) => {
+    if (primaryKey !== "id" && key === primaryKey) {
+      throw new Error(
+        `createHandler: Field ${key} is reserved when primaryKey is configured; use id in responses and omit the original primary key from writes`,
+      );
+    }
     if (value === "") {
       delete data[key];
       return;

--- a/packages/ra-data-simple-prisma/src/deleteHandler.ts
+++ b/packages/ra-data-simple-prisma/src/deleteHandler.ts
@@ -2,6 +2,7 @@ import { auditHandler } from "./audit/auditHandler";
 import { AuditOptions } from "./audit/types";
 import { getModel } from "./getModel";
 import { DeleteRequest } from "./Http";
+import { mapPrimaryKeyToId } from "./mapPrimaryKeyToId";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type DeleteOptions = {
@@ -43,7 +44,7 @@ export const deleteHandler = async <
     await auditHandler(req, options?.audit);
   }
 
-  const response = { data: deleted };
+  const response = { data: mapPrimaryKeyToId(deleted, primaryKey) };
 
   return response;
 };

--- a/packages/ra-data-simple-prisma/src/getInfiniteListHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getInfiniteListHandler.ts
@@ -1,18 +1,20 @@
-import { GetListRequest } from "./Http";
+import { stringify } from "deverything";
 import { extractOrderBy } from "./extractOrderBy";
 import { extractSkipTake } from "./extractSkipTake";
 import { extractWhere } from "./extractWhere";
 import { GetListArgs, GetListOptions } from "./getListHandler";
-import { stringify } from "deverything";
 import { getModel } from "./getModel";
+import { GetListRequest } from "./Http";
+import { mapPrimaryKeyToId } from "./mapPrimaryKeyToId";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export const getInfiniteListHandler = async <Args extends GetListArgs>(
   req: GetListRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: GetListOptions<Args>
+  options?: GetListOptions<Args>,
 ) => {
   const model = getModel(req, prismaClient);
+  const primaryKey = options?.primaryKey ?? "id";
 
   let queryArgs: {
     findManyArg: {
@@ -96,7 +98,7 @@ export const getInfiniteListHandler = async <Args extends GetListArgs>(
 
   // RESPOND WITH DATA
   const response = {
-    data,
+    data: mapPrimaryKeyToId(data, primaryKey),
     pageInfo: {
       hasPreviousPage: skip > 0,
       hasNextPage,

--- a/packages/ra-data-simple-prisma/src/getListHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getListHandler.ts
@@ -1,9 +1,10 @@
 import { stringify } from "deverything";
-import { GetListRequest } from "./Http";
 import { extractOrderBy } from "./extractOrderBy";
 import { extractSkipTake } from "./extractSkipTake";
 import { extractWhere, FilterMode } from "./extractWhere";
 import { getModel } from "./getModel";
+import { GetListRequest } from "./Http";
+import { mapPrimaryKeyToId } from "./mapPrimaryKeyToId";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type GetListArgs = {
@@ -16,20 +17,18 @@ export type GetListArgs = {
 export type GetListOptions<Args extends GetListArgs = GetListArgs> = Args & {
   noNullsOnSort?: string[]; // TODO: to be keyof Args["orderBy"] CAREFUL field must be nullable, or prisma will throw
   debug?: boolean;
-  transformRow?: (
-    row: any,
-    rowIndex: number,
-    rows: any[]
-  ) => any | Promise<any>;
+  primaryKey?: string;
+  transformRow?: (row: any, rowIndex: number, rows: any[]) => any | Promise<any>;
   filterMode?: FilterMode;
 };
 
 export const getListHandler = async <Args extends GetListArgs>(
   req: GetListRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: GetListOptions<Args>
+  options?: GetListOptions<Args>,
 ) => {
   const model = getModel(req, prismaClient);
+  const primaryKey = options?.primaryKey ?? "id";
 
   let queryArgs: {
     findManyArg: {
@@ -130,7 +129,7 @@ export const getListHandler = async <Args extends GetListArgs>(
 
   // RESPOND WITH DATA
   const response = {
-    data,
+    data: mapPrimaryKeyToId(data, primaryKey),
     total,
   };
 

--- a/packages/ra-data-simple-prisma/src/getManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getManyHandler.ts
@@ -1,5 +1,6 @@
 import { getModel } from "./getModel";
 import { GetManyRequest } from "./Http";
+import { mapPrimaryKeyToId } from "./mapPrimaryKeyToId";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type GetManyArgs = {
@@ -33,7 +34,7 @@ export const getManyHandler = async <Args extends GetManyArgs>(
   // TRANSFORM
   const data = options?.transformRow ? await Promise.all(rows.map(options.transformRow)) : rows;
 
-  const response = { data };
+  const response = { data: mapPrimaryKeyToId(data, primaryKey) };
 
   return response;
 };

--- a/packages/ra-data-simple-prisma/src/getManyReferenceHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getManyReferenceHandler.ts
@@ -1,9 +1,10 @@
-import { GetManyReferenceRequest } from "./Http";
-import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 import { extractOrderBy } from "./extractOrderBy";
 import { extractSkipTake } from "./extractSkipTake";
 import { extractWhere, FilterMode } from "./extractWhere";
 import { getModel } from "./getModel";
+import { GetManyReferenceRequest } from "./Http";
+import { mapPrimaryKeyToId } from "./mapPrimaryKeyToId";
+import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type GetManyReferenceArgs = {
   include?: object | null;
@@ -14,6 +15,7 @@ export type GetManyReferenceOptions<
   Args extends GetManyReferenceArgs = GetManyReferenceArgs
 > = Args & {
   debug?: boolean;
+  primaryKey?: string;
   transformRow?: (data: any) => any | Promise<any>;
   filterMode?: FilterMode;
 };
@@ -23,9 +25,10 @@ export const getManyReferenceHandler = async <
 >(
   req: GetManyReferenceRequest,
   prismaClient: PrismaClientOrDynamicClientExtension,
-  options?: GetManyReferenceOptions<Args>
+  options?: GetManyReferenceOptions<Args>,
 ) => {
   const { id, target } = req.params;
+  const primaryKey = options?.primaryKey ?? "id";
   const model = getModel(req, prismaClient);
   const orderBy = extractOrderBy(req);
 
@@ -54,7 +57,7 @@ export const getManyReferenceHandler = async <
     ? await Promise.all(rows.map(options.transformRow))
     : rows;
 
-  const response = { data, total };
+  const response = { data: mapPrimaryKeyToId(data, primaryKey), total };
 
   return response;
 };

--- a/packages/ra-data-simple-prisma/src/getOneHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getOneHandler.ts
@@ -1,5 +1,6 @@
 import { getModel } from "./getModel";
 import { GetOneRequest } from "./Http";
+import { mapPrimaryKeyToId } from "./mapPrimaryKeyToId";
 import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type GetOneArgs = {
@@ -40,7 +41,7 @@ export const getOneHandler = async <Args extends GetOneArgs>(
   if (options?.debug) console.log("getOneHandler:afterTransform", transformedRow);
 
   // RESPONSE STAGE
-  const response = { data: transformedRow };
+  const response = { data: mapPrimaryKeyToId(transformedRow, primaryKey) };
 
   return response;
 };

--- a/packages/ra-data-simple-prisma/src/mapPrimaryKeyToId.ts
+++ b/packages/ra-data-simple-prisma/src/mapPrimaryKeyToId.ts
@@ -1,0 +1,32 @@
+const mapRowPrimaryKeyToId = <T>(row: T, primaryKey: string): T => {
+  if (primaryKey === "id" || row == null || typeof row !== "object") {
+    return row;
+  }
+
+  const hasIdField = Object.prototype.hasOwnProperty.call(row, "id");
+  const existingId = (row as any).id;
+  const keyValue = (row as any)[primaryKey];
+
+  if (typeof keyValue === "undefined") {
+    return row;
+  }
+
+  if (hasIdField && typeof existingId !== "undefined" && existingId !== keyValue) {
+    console.warn(`ra-data-simple-prisma: overwriting existing id with value from primaryKey "${primaryKey}"`);
+  }
+
+  const { [primaryKey]: _, ...rest } = row as any;
+
+  return {
+    ...rest,
+    id: keyValue,
+  };
+};
+
+export const mapPrimaryKeyToId = <T>(data: T, primaryKey: string): T => {
+  if (Array.isArray(data)) {
+    return data.map((row) => mapRowPrimaryKeyToId(row, primaryKey)) as T;
+  }
+
+  return mapRowPrimaryKeyToId(data, primaryKey);
+};

--- a/packages/ra-data-simple-prisma/src/updateHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateHandler.ts
@@ -5,6 +5,7 @@ import { getModel } from "./getModel";
 import type { UpdateRequest } from "./Http";
 import { isNotField } from "./lib/isNotField";
 import type { SetExplicitConnection, SetImplicitConnection, SetImplicitShortcut } from "./lib/types";
+import { mapPrimaryKeyToId } from "./mapPrimaryKeyToId";
 import type { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 
 export type { SetExplicitConnection, SetImplicitConnection, SetImplicitShortcut };
@@ -40,6 +41,11 @@ export type UpdateOptions<Args extends UpdateArgs = UpdateArgs> = Args & {
 
 export const reduceData = (data, options: UpdateOptions) => {
   return Object.entries(data).reduce((fields, [key, value]) => {
+    if (options?.primaryKey && options.primaryKey !== "id" && key === options.primaryKey) {
+      throw new Error(
+        `updateHandler: Field ${key} is reserved when primaryKey is configured; use params.id and omit the original primary key from writes`,
+      );
+    }
     if (isNotField(key)) return fields;
     if (options?.skipFields?.[key]) return fields;
 
@@ -182,7 +188,7 @@ export const updateHandler = async <Args extends UpdateArgs>(
     await auditHandler(req, options.audit);
   }
 
-  const response = { data: updated };
+  const response = { data: mapPrimaryKeyToId(updated, primaryKey) };
 
   return response;
 };

--- a/packages/ra-data-simple-prisma/tests/createHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/createHandler.test.ts
@@ -106,6 +106,15 @@ describe("createHandler - allowOnlyFields", () => {
     const req = makeReq({ title: "Hi", _count: 3 });
     await expect(createHandler(req, {} as never, { allowOnlyFields: { title: true } })).resolves.toBeDefined();
   });
+
+  test("throws when payload includes the configured custom primary key field", async () => {
+    mockGetModel.mockReturnValue(makeMockModel() as never);
+
+    const req = makeReq({ title: "Hi", IrregularPrimaryKeyId: 42 });
+    await expect(createHandler(req, {} as never, { primaryKey: "IrregularPrimaryKeyId" })).rejects.toThrow(
+      "createHandler: Field IrregularPrimaryKeyId is reserved when primaryKey is configured; use id in responses and omit the original primary key from writes",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ra-data-simple-prisma/tests/deleteHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/deleteHandler.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { deleteHandler } from "../src/deleteHandler";
+import type { DeleteRequest } from "../src/Http";
+
+jest.mock("../src/getModel");
+jest.mock("../src/audit/auditHandler");
+
+import { auditHandler } from "../src/audit/auditHandler";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockAuditHandler = auditHandler as jest.MockedFunction<typeof auditHandler>;
+
+function makeReq(id: string | number, resource = "post"): DeleteRequest {
+  return {
+    method: "delete",
+    resource,
+    params: { id, previousData: {} },
+  };
+}
+
+function makeMockModel() {
+  return {
+    delete: jest.fn().mockResolvedValue({ id: 1, title: "Deleted" } as never),
+    update: jest.fn().mockResolvedValue({ id: 1, title: "Deleted" } as never),
+  };
+}
+
+describe("deleteHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("calls model.delete with where { id } and returns { data }", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await deleteHandler(makeReq(42), {} as never);
+
+    expect(model.delete).toHaveBeenCalledWith({
+      where: { id: 42 },
+    });
+    expect(model.update).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: { id: 1, title: "Deleted" } });
+  });
+
+  test("uses soft delete field with model.update and current date", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await deleteHandler(makeReq(9), {} as never, {
+      softDeleteField: "deletedAt",
+    });
+
+    expect(model.delete).not.toHaveBeenCalled();
+    expect(model.update).toHaveBeenCalledTimes(1);
+    expect(model.update).toHaveBeenCalledWith({
+      where: { id: 9 },
+      data: {
+        deletedAt: expect.any(Date),
+      },
+    });
+    expect(result).toEqual({ data: { id: 1, title: "Deleted" } });
+  });
+
+  test("calls auditHandler when audit options are provided", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockAuditHandler.mockResolvedValue(undefined as never);
+
+    const req = makeReq(3);
+    const auditOptions = {
+      model: { create: jest.fn() },
+      authProvider: {} as never,
+    };
+
+    await deleteHandler(req, {} as never, { audit: auditOptions });
+
+    expect(mockAuditHandler).toHaveBeenCalledWith(req, auditOptions);
+  });
+
+  test("does not call auditHandler when audit options are absent", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await deleteHandler(makeReq(3), {} as never);
+
+    expect(mockAuditHandler).not.toHaveBeenCalled();
+  });
+
+  test("uses custom primaryKey in where clause and maps response to id", async () => {
+    const model = {
+      delete: jest.fn().mockResolvedValue({ StatusId: 55, name: "Archived" } as never),
+      update: jest.fn(),
+    };
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await deleteHandler(makeReq("archived"), {} as never, {
+      primaryKey: "StatusId",
+    });
+
+    expect(model.delete).toHaveBeenCalledWith({
+      where: { StatusId: "archived" },
+    });
+    expect(result).toEqual({
+      data: { id: 55, name: "Archived" },
+    });
+    expect(result.data).not.toHaveProperty("StatusId");
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/deleteManyHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/deleteManyHandler.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { deleteManyHandler } from "../src/deleteManyHandler";
+import type { DeleteManyRequest } from "../src/Http";
+
+jest.mock("../src/getModel");
+jest.mock("../src/audit/auditHandler");
+
+import { auditHandler } from "../src/audit/auditHandler";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockAuditHandler = auditHandler as jest.MockedFunction<typeof auditHandler>;
+
+function makeReq(ids: Array<string | number>, resource = "post"): DeleteManyRequest {
+  return {
+    method: "deleteMany",
+    resource,
+    params: { ids },
+  };
+}
+
+function makeMockModel() {
+  return {
+    deleteMany: jest.fn().mockResolvedValue({ count: 2 } as never),
+    updateMany: jest.fn().mockResolvedValue({ count: 2 } as never),
+  };
+}
+
+describe("deleteManyHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("calls model.deleteMany with where { id: { in: ids } } and returns ids", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await deleteManyHandler(makeReq([1, 2]), {} as never);
+
+    expect(model.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: [1, 2] } },
+    });
+    expect(model.updateMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: [1, 2] });
+  });
+
+  test("uses soft delete field with model.updateMany and current date", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await deleteManyHandler(makeReq([9, 10]), {} as never, {
+      softDeleteField: "deletedAt",
+    });
+
+    expect(model.deleteMany).not.toHaveBeenCalled();
+    expect(model.updateMany).toHaveBeenCalledTimes(1);
+    expect(model.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: [9, 10] } },
+      data: {
+        deletedAt: expect.any(Date),
+      },
+    });
+    expect(result).toEqual({ data: [9, 10] });
+  });
+
+  test("calls auditHandler when audit options are provided", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockAuditHandler.mockResolvedValue(undefined as never);
+
+    const req = makeReq([3, 4]);
+    const auditOptions = {
+      model: { create: jest.fn() },
+      authProvider: {} as never,
+    };
+
+    await deleteManyHandler(req, {} as never, { audit: auditOptions });
+
+    expect(mockAuditHandler).toHaveBeenCalledWith(req, auditOptions);
+  });
+
+  test("does not call auditHandler when audit options are absent", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await deleteManyHandler(makeReq([3, 4]), {} as never);
+
+    expect(mockAuditHandler).not.toHaveBeenCalled();
+  });
+
+  test("uses custom primaryKey in where clause and still returns the requested ids", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await deleteManyHandler(makeReq(["archived", "draft"]), {} as never, {
+      primaryKey: "StatusId",
+    });
+
+    expect(model.deleteMany).toHaveBeenCalledWith({
+      where: { StatusId: { in: ["archived", "draft"] } },
+    });
+    expect(result).toEqual({ data: ["archived", "draft"] });
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/getInfiniteListHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/getInfiniteListHandler.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { getInfiniteListHandler } from "../src/getInfiniteListHandler";
+import type { GetListRequest } from "../src/Http";
+
+jest.mock("../src/getModel");
+jest.mock("../src/extractWhere");
+jest.mock("../src/extractOrderBy");
+jest.mock("../src/extractSkipTake");
+
+import { extractOrderBy } from "../src/extractOrderBy";
+import { extractSkipTake } from "../src/extractSkipTake";
+import { extractWhere } from "../src/extractWhere";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockExtractWhere = extractWhere as jest.MockedFunction<typeof extractWhere>;
+const mockExtractOrderBy = extractOrderBy as jest.MockedFunction<typeof extractOrderBy>;
+const mockExtractSkipTake = extractSkipTake as jest.MockedFunction<typeof extractSkipTake>;
+
+function makeReq(overrides: Partial<GetListRequest["params"]> = {}): GetListRequest {
+  return {
+    method: "getList",
+    resource: "post",
+    params: {
+      pagination: { page: 1, perPage: 2 },
+      sort: { field: "id", order: "ASC" },
+      filter: {},
+      ...overrides,
+    },
+  };
+}
+
+function makeMockModel() {
+  return {
+    findMany: jest.fn().mockResolvedValue([
+      { id: 1, title: "A" },
+      { id: 2, title: "B" },
+      { id: 3, title: "C" },
+    ] as never),
+  };
+}
+
+describe("getInfiniteListHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExtractWhere.mockReturnValue({} as never);
+    mockExtractOrderBy.mockReturnValue({ id: "asc" } as never);
+    mockExtractSkipTake.mockReturnValue({ skip: 0, take: 2 } as never);
+  });
+
+  test("calls findMany with merged where, orderBy, and take + 1", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractWhere.mockReturnValue({ status: "client" } as never);
+
+    await getInfiniteListHandler(makeReq(), {} as never, {
+      where: { status: "server" },
+      include: { comments: true },
+      select: { id: true },
+    });
+
+    expect(model.findMany).toHaveBeenCalledWith({
+      include: { comments: true },
+      orderBy: { id: "asc" },
+      select: { id: true },
+      skip: 0,
+      take: 3,
+      where: { status: "server" },
+    });
+  });
+
+  test("uses options.orderBy and skips request sort extraction when provided", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getInfiniteListHandler(makeReq(), {} as never, {
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(mockExtractOrderBy).not.toHaveBeenCalled();
+    expect(model.findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { createdAt: "desc" } }));
+  });
+
+  test("adds not-null constraint for sorted field in noNullsOnSort", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractWhere.mockReturnValue({ status: "client" } as never);
+
+    await getInfiniteListHandler(makeReq({ sort: { field: "title", order: "ASC" } }), {} as never, {
+      where: { status: "server" },
+      noNullsOnSort: ["title"],
+    });
+
+    expect(model.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { status: "server", title: { not: null } },
+      }),
+    );
+  });
+
+  test("returns pageInfo with next page and slices extra record", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getInfiniteListHandler(makeReq(), {} as never);
+
+    expect(result).toEqual({
+      data: [
+        { id: 1, title: "A" },
+        { id: 2, title: "B" },
+      ],
+      pageInfo: {
+        hasPreviousPage: false,
+        hasNextPage: true,
+      },
+    });
+  });
+
+  test("returns hasPreviousPage when skip is greater than zero", async () => {
+    const model = {
+      findMany: jest.fn().mockResolvedValue([
+        { id: 3, title: "C" },
+        { id: 4, title: "D" },
+      ] as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractSkipTake.mockReturnValue({ skip: 2, take: 2 } as never);
+
+    const result = await getInfiniteListHandler(makeReq(), {} as never);
+
+    expect(result.pageInfo).toEqual({
+      hasPreviousPage: true,
+      hasNextPage: false,
+    });
+  });
+
+  test("applies transformRow to returned rows", async () => {
+    const model = {
+      findMany: jest.fn().mockResolvedValue([
+        { id: 1, title: "A" },
+        { id: 2, title: "B" },
+      ] as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getInfiniteListHandler(makeReq(), {} as never, {
+      transformRow: async (row) => ({ ...row, title: row.title.toLowerCase() }),
+    });
+
+    expect(result.data).toEqual([
+      { id: 1, title: "a" },
+      { id: 2, title: "b" },
+    ]);
+  });
+
+  test("maps custom primaryKey to id in response and removes original key", async () => {
+    const model = {
+      findMany: jest.fn().mockResolvedValue([
+        { StatusId: 10, name: "Published" },
+        { StatusId: 20, name: "Draft" },
+      ] as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractSkipTake.mockReturnValue({ skip: 0, take: 5 } as never);
+
+    const result = await getInfiniteListHandler(makeReq(), {} as never, {
+      primaryKey: "StatusId",
+    });
+
+    expect(result.data).toEqual([
+      { id: 10, name: "Published" },
+      { id: 20, name: "Draft" },
+    ]);
+    expect(result.data[0]).not.toHaveProperty("StatusId");
+  });
+
+  test("debug logs requestWhere and queryArgs", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractWhere.mockReturnValue({ status: "active" } as never);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await getInfiniteListHandler(makeReq(), {} as never, { debug: true });
+
+    expect(logSpy).toHaveBeenCalledWith("getInfiniteListHandler:requestWhere", expect.any(String));
+    expect(logSpy).toHaveBeenCalledWith("getInfiniteListHandler:queryArgs", expect.any(String));
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/getListHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/getListHandler.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { getListHandler } from "../src/getListHandler";
+import type { GetListRequest } from "../src/Http";
+
+jest.mock("../src/getModel");
+jest.mock("../src/extractWhere");
+jest.mock("../src/extractOrderBy");
+jest.mock("../src/extractSkipTake");
+
+import { extractOrderBy } from "../src/extractOrderBy";
+import { extractSkipTake } from "../src/extractSkipTake";
+import { extractWhere } from "../src/extractWhere";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockExtractWhere = extractWhere as jest.MockedFunction<typeof extractWhere>;
+const mockExtractOrderBy = extractOrderBy as jest.MockedFunction<typeof extractOrderBy>;
+const mockExtractSkipTake = extractSkipTake as jest.MockedFunction<typeof extractSkipTake>;
+
+function makeReq(overrides: Partial<GetListRequest["params"]> = {}): GetListRequest {
+  return {
+    method: "getList",
+    resource: "post",
+    params: {
+      pagination: { page: 1, perPage: 10 },
+      sort: { field: "id", order: "ASC" },
+      filter: {},
+      ...overrides,
+    },
+  };
+}
+
+function makeMockModel() {
+  return {
+    findMany: jest.fn().mockResolvedValue([{ id: 1, title: "A" }] as never),
+    count: jest.fn().mockResolvedValue(1 as never),
+  };
+}
+
+describe("getListHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExtractWhere.mockReturnValue({} as never);
+    mockExtractOrderBy.mockReturnValue({ id: "asc" } as never);
+    mockExtractSkipTake.mockReturnValue({ skip: 0, take: 10 } as never);
+  });
+
+  test("calls findMany/count with merged where, orderBy, and pagination", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractWhere.mockReturnValue({ status: "client" } as never);
+
+    await getListHandler(makeReq(), {} as never, {
+      where: { status: "server" },
+      include: { comments: true },
+      select: { id: true },
+    });
+
+    expect(model.findMany).toHaveBeenCalledWith({
+      include: { comments: true },
+      orderBy: { id: "asc" },
+      select: { id: true },
+      skip: 0,
+      take: 10,
+      where: { status: "server" },
+    });
+
+    expect(model.count).toHaveBeenCalledWith({
+      where: { status: "server" },
+    });
+  });
+
+  test("uses options.orderBy and skips request sort extraction when provided", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getListHandler(makeReq(), {} as never, {
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(mockExtractOrderBy).not.toHaveBeenCalled();
+    expect(model.findMany).toHaveBeenCalledWith(expect.objectContaining({ orderBy: { createdAt: "desc" } }));
+  });
+
+  test("adds not-null constraint for sorted field in noNullsOnSort", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractWhere.mockReturnValue({ status: "client" } as never);
+
+    await getListHandler(makeReq({ sort: { field: "title", order: "ASC" } }), {} as never, {
+      where: { status: "server" },
+      noNullsOnSort: ["title"],
+    });
+
+    expect(model.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { status: "server", title: { not: null } },
+      }),
+    );
+
+    expect(model.count).toHaveBeenCalledWith({
+      where: { status: "server", title: { not: null } },
+    });
+  });
+
+  test("applies transformRow to each row", async () => {
+    const model = {
+      findMany: jest.fn().mockResolvedValue([
+        { id: 1, title: "A" },
+        { id: 2, title: "B" },
+      ] as never),
+      count: jest.fn().mockResolvedValue(2 as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getListHandler(makeReq(), {} as never, {
+      transformRow: async (row) => ({ ...row, title: row.title.toLowerCase() }),
+    });
+
+    expect(result.data).toEqual([
+      { id: 1, title: "a" },
+      { id: 2, title: "b" },
+    ]);
+    expect(result.total).toBe(2);
+  });
+
+  test("maps custom primaryKey to id in response and removes original key", async () => {
+    const model = {
+      findMany: jest.fn().mockResolvedValue([{ StatusId: 10, name: "Published" }] as never),
+      count: jest.fn().mockResolvedValue(1 as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getListHandler(makeReq(), {} as never, {
+      primaryKey: "StatusId",
+    });
+
+    expect(result.data[0]).toEqual({ id: 10, name: "Published" });
+    expect(result.data[0]).not.toHaveProperty("StatusId");
+  });
+
+  test("debug logs requestWhere, queryArgs, and total", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockExtractWhere.mockReturnValue({ status: "active" } as never);
+
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await getListHandler(makeReq(), {} as never, { debug: true });
+
+    expect(debugSpy).toHaveBeenCalledWith("getListHandler:requestWhere", expect.any(String));
+    expect(logSpy).toHaveBeenCalledWith("getListHandler:queryArgs", expect.any(String));
+    expect(logSpy).toHaveBeenCalledWith("getListHandler:total", 1);
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/getManyHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/getManyHandler.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { getManyHandler } from "../src/getManyHandler";
+import type { GetManyRequest } from "../src/Http";
+
+jest.mock("../src/getModel");
+
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+
+function makeReq(ids: Array<string | number>, resource = "post"): GetManyRequest {
+  return {
+    method: "getMany",
+    resource,
+    params: { ids },
+  };
+}
+
+function makeMockModel() {
+  return {
+    findMany: jest.fn().mockResolvedValue([
+      { id: 1, title: "A" },
+      { id: 2, title: "B" },
+    ] as never),
+  };
+}
+
+describe("getManyHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("calls model.findMany with where { id: { in: ids } } and returns data", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getManyHandler(makeReq([1, 2]), {} as never);
+
+    expect(model.findMany).toHaveBeenCalledWith({
+      include: undefined,
+      select: undefined,
+      where: { id: { in: [1, 2] } },
+    });
+
+    expect(result).toEqual({
+      data: [
+        { id: 1, title: "A" },
+        { id: 2, title: "B" },
+      ],
+    });
+  });
+
+  test("passes include option to model.findMany", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getManyHandler(makeReq([1]), {} as never, {
+      include: { comments: true },
+    });
+
+    expect(model.findMany).toHaveBeenCalledWith(expect.objectContaining({ include: { comments: true } }));
+  });
+
+  test("passes select option to model.findMany", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getManyHandler(makeReq([1]), {} as never, {
+      select: { id: true, title: true },
+    });
+
+    expect(model.findMany).toHaveBeenCalledWith(expect.objectContaining({ select: { id: true, title: true } }));
+  });
+
+  test("applies sync transformRow to each row", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getManyHandler(makeReq([1, 2]), {} as never, {
+      transformRow: (row) => ({ ...row, title: row.title.toLowerCase() }),
+    });
+
+    expect(result).toEqual({
+      data: [
+        { id: 1, title: "a" },
+        { id: 2, title: "b" },
+      ],
+    });
+  });
+
+  test("applies async transformRow to each row", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getManyHandler(makeReq([1, 2]), {} as never, {
+      transformRow: async (row) => ({ ...row, loaded: await Promise.resolve(true) }),
+    });
+
+    expect(result).toEqual({
+      data: [
+        { id: 1, title: "A", loaded: true },
+        { id: 2, title: "B", loaded: true },
+      ],
+    });
+  });
+
+  test("uses custom primaryKey in where and maps response to id", async () => {
+    const model = {
+      findMany: jest.fn().mockResolvedValue([
+        { StatusId: 10, name: "Published" },
+        { StatusId: 20, name: "Draft" },
+      ] as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getManyHandler(makeReq([10, 20]), {} as never, {
+      primaryKey: "StatusId",
+    });
+
+    expect(model.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { StatusId: { in: [10, 20] } } }));
+
+    expect(result.data).toEqual([
+      { id: 10, name: "Published" },
+      { id: 20, name: "Draft" },
+    ]);
+    expect(result.data[0]).not.toHaveProperty("StatusId");
+    expect(result.data[1]).not.toHaveProperty("StatusId");
+  });
+
+  test("forwards string ids as-is", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getManyHandler(makeReq(["a", "b"]), {} as never);
+
+    expect(model.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: { in: ["a", "b"] } } }));
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/getManyReferenceHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/getManyReferenceHandler.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { getManyReferenceHandler } from "../src/getManyReferenceHandler";
+import type { GetManyReferenceRequest } from "../src/Http";
+
+jest.mock("../src/getModel");
+jest.mock("../src/extractWhere");
+jest.mock("../src/extractOrderBy");
+jest.mock("../src/extractSkipTake");
+
+import { extractOrderBy } from "../src/extractOrderBy";
+import { extractSkipTake } from "../src/extractSkipTake";
+import { extractWhere } from "../src/extractWhere";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockExtractWhere = extractWhere as jest.MockedFunction<typeof extractWhere>;
+const mockExtractOrderBy = extractOrderBy as jest.MockedFunction<typeof extractOrderBy>;
+const mockExtractSkipTake = extractSkipTake as jest.MockedFunction<typeof extractSkipTake>;
+
+function makeReq(overrides: Partial<GetManyReferenceRequest["params"]> = {}): GetManyReferenceRequest {
+  return {
+    method: "getManyReference",
+    resource: "comment",
+    params: {
+      id: 7,
+      target: "postId",
+      filter: {},
+      pagination: { page: 1, perPage: 10 },
+      sort: { field: "id", order: "ASC" },
+      ...overrides,
+    },
+  };
+}
+
+function makeModel() {
+  return {
+    findMany: jest.fn().mockResolvedValue([
+      { id: 1, body: "first" },
+      { id: 2, body: "second" },
+    ] as never),
+    count: jest.fn().mockResolvedValue(2 as never),
+  };
+}
+
+describe("getManyReferenceHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExtractWhere.mockReturnValue({ status: "approved" } as never);
+    mockExtractOrderBy.mockReturnValue({ createdAt: "desc" } as never);
+    mockExtractSkipTake.mockReturnValue({ skip: 10, take: 10 } as never);
+  });
+
+  test("queries findMany and count with target id merged into where", async () => {
+    const model = makeModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getManyReferenceHandler(makeReq(), {} as never, {
+      include: { author: true },
+      select: { id: true },
+      filterMode: "insensitive",
+    });
+
+    expect(mockExtractWhere).toHaveBeenCalledWith(expect.any(Object), {
+      filterMode: "insensitive",
+    });
+    expect(model.findMany).toHaveBeenCalledWith({
+      include: { author: true },
+      select: { id: true },
+      where: { postId: 7, status: "approved" },
+      orderBy: { createdAt: "desc" },
+      skip: 10,
+      take: 10,
+    });
+    expect(model.count).toHaveBeenCalledWith({ where: { postId: 7, status: "approved" } });
+    expect(result).toEqual({
+      data: [
+        { id: 1, body: "first" },
+        { id: 2, body: "second" },
+      ],
+      total: 2,
+    });
+  });
+
+  test("applies transformRow when provided", async () => {
+    const model = makeModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getManyReferenceHandler(makeReq(), {} as never, {
+      transformRow: async (row) => ({ ...row, body: row.body.toUpperCase() }),
+    });
+
+    expect(result.data).toEqual([
+      { id: 1, body: "FIRST" },
+      { id: 2, body: "SECOND" },
+    ]);
+  });
+
+  test("maps custom primaryKey to id in response", async () => {
+    const model = {
+      findMany: jest.fn().mockResolvedValue([
+        { CommentId: 11, body: "first" },
+        { CommentId: 12, body: "second" },
+      ] as never),
+      count: jest.fn().mockResolvedValue(2 as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getManyReferenceHandler(makeReq(), {} as never, {
+      primaryKey: "CommentId",
+    });
+
+    expect(result.data).toEqual([
+      { id: 11, body: "first" },
+      { id: 12, body: "second" },
+    ]);
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/getOneHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/getOneHandler.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { getOneHandler } from "../src/getOneHandler";
+import type { GetOneRequest } from "../src/Http";
+
+jest.mock("../src/getModel");
+
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+
+function makeReq(id: string | number, resource = "post"): GetOneRequest {
+  return {
+    method: "getOne",
+    resource,
+    params: { id },
+  };
+}
+
+function makeMockModel() {
+  return {
+    findUnique: jest.fn().mockResolvedValue({ id: 1, title: "Post" } as never),
+  };
+}
+
+describe("getOneHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("calls model.findUnique with where { id } and returns { data }", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getOneHandler(makeReq(42), {} as never);
+
+    expect(model.findUnique).toHaveBeenCalledWith({
+      where: { id: 42 },
+      select: undefined,
+      include: undefined,
+    });
+    expect(result).toEqual({ data: { id: 1, title: "Post" } });
+  });
+
+  test("passes select option to model.findUnique", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getOneHandler(makeReq(1), {} as never, { select: { id: true, title: true } });
+
+    expect(model.findUnique).toHaveBeenCalledWith(expect.objectContaining({ select: { id: true, title: true } }));
+  });
+
+  test("passes include option to model.findUnique", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getOneHandler(makeReq(1), {} as never, { include: { comments: true } });
+
+    expect(model.findUnique).toHaveBeenCalledWith(expect.objectContaining({ include: { comments: true } }));
+  });
+
+  test("applies sync transform before returning response", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getOneHandler(makeReq(1), {} as never, {
+      transform: (row) => ({ ...row, slug: "post-1" }),
+    });
+
+    expect(result).toEqual({ data: { id: 1, title: "Post", slug: "post-1" } });
+  });
+
+  test("applies async transform before returning response", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getOneHandler(makeReq(1), {} as never, {
+      transform: async (row) => ({ ...row, loaded: await Promise.resolve(true) }),
+    });
+
+    expect(result).toEqual({ data: { id: 1, title: "Post", loaded: true } });
+  });
+
+  test("returns null data when model.findUnique returns null", async () => {
+    const model = {
+      findUnique: jest.fn().mockResolvedValue(null as never),
+    };
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await getOneHandler(makeReq(999), {} as never);
+
+    expect(result).toEqual({ data: null });
+  });
+
+  test("debug logs where, beforeTransform, and afterTransform", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await getOneHandler(makeReq(42), {} as never, { debug: true });
+
+    expect(consoleSpy).toHaveBeenCalledWith("getOneHandler:where", { id: 42 });
+    expect(consoleSpy).toHaveBeenCalledWith("getOneHandler:beforeTransform", { id: 1, title: "Post" });
+    expect(consoleSpy).toHaveBeenCalledWith("getOneHandler:afterTransform", { id: 1, title: "Post" });
+  });
+
+  test("uses string ids as-is in where clause", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await getOneHandler(makeReq("abc-123"), {} as never);
+
+    expect(model.findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "abc-123" } }));
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/mapPrimaryKeyToId.test.ts
+++ b/packages/ra-data-simple-prisma/tests/mapPrimaryKeyToId.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { mapPrimaryKeyToId } from "../src/mapPrimaryKeyToId";
+
+describe("mapPrimaryKeyToId", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("returns data unchanged when primaryKey is id", () => {
+    const row = { id: 42, title: "Post" };
+
+    const result = mapPrimaryKeyToId(row, "id");
+
+    expect(result).toBe(row);
+  });
+
+  test("returns null and primitive values unchanged", () => {
+    expect(mapPrimaryKeyToId(null, "IrregularPrimaryKeyId")).toBeNull();
+    expect(mapPrimaryKeyToId("value", "IrregularPrimaryKeyId")).toBe("value");
+    expect(mapPrimaryKeyToId(42, "IrregularPrimaryKeyId")).toBe(42);
+  });
+
+  test("returns row unchanged when configured primary key is missing", () => {
+    const row = { id: 7, title: "Post" };
+
+    const result = mapPrimaryKeyToId(row, "IrregularPrimaryKeyId");
+
+    expect(result).toBe(row);
+  });
+
+  test("logs a warning when mapping overwrites an existing id", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = mapPrimaryKeyToId({ id: 10, IrregularPrimaryKeyId: 42 }, "IrregularPrimaryKeyId");
+
+    expect(result).toMatchObject({ id: 42 });
+    expect(result).not.toHaveProperty("IrregularPrimaryKeyId");
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ra-data-simple-prisma: overwriting existing id with value from primaryKey "IrregularPrimaryKeyId"',
+    );
+  });
+
+  test("does not log when existing id already matches mapped primary key", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = mapPrimaryKeyToId({ id: 42, IrregularPrimaryKeyId: 42 }, "IrregularPrimaryKeyId");
+
+    expect(result).toMatchObject({ id: 42 });
+    expect(result).not.toHaveProperty("IrregularPrimaryKeyId");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not log when there is no existing id field", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = mapPrimaryKeyToId({ IrregularPrimaryKeyId: 42 }, "IrregularPrimaryKeyId");
+
+    expect(result).toMatchObject({ id: 42 });
+    expect(result).not.toHaveProperty("IrregularPrimaryKeyId");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("maps arrays of rows", () => {
+    const result = mapPrimaryKeyToId(
+      [
+        { IrregularPrimaryKeyId: 1, title: "First" },
+        { IrregularPrimaryKeyId: 2, title: "Second" },
+      ],
+      "IrregularPrimaryKeyId",
+    );
+
+    expect(result).toEqual([
+      { id: 1, title: "First" },
+      { id: 2, title: "Second" },
+    ]);
+  });
+});

--- a/packages/ra-data-simple-prisma/tests/updateHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/updateHandler.test.ts
@@ -65,6 +65,14 @@ describe("reduceData", () => {
     );
   });
 
+  test("throws when data includes the configured custom primary key field", () => {
+    expect(() =>
+      reduceData({ title: "Hi", IrregularPrimaryKeyId: 42 }, { primaryKey: "IrregularPrimaryKeyId" }),
+    ).toThrow(
+      "updateHandler: Field IrregularPrimaryKeyId is reserved when primaryKey is configured; use params.id and omit the original primary key from writes",
+    );
+  });
+
   // set — implicit shortcut: set: { tags: "id" }
   test("set with string (implicit shortcut) transforms array to { set: [{id},...] }", () => {
     const result = reduceData({ tags: [1, 2, 3] }, { set: { tags: "id" } });
@@ -235,5 +243,14 @@ describe("updateHandler", () => {
     await updateHandler(req, {} as never);
 
     expect(model.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "abc-123" } }));
+  });
+
+  test("rejects payload data containing the configured custom primary key field", async () => {
+    mockGetModel.mockReturnValue(makeMockModel() as never);
+
+    const req = makeReq(1, { title: "Updated", IrregularPrimaryKeyId: 42 });
+    await expect(updateHandler(req, {} as never, { primaryKey: "IrregularPrimaryKeyId" })).rejects.toThrow(
+      "updateHandler: Field IrregularPrimaryKeyId is reserved when primaryKey is configured; use params.id and omit the original primary key from writes",
+    );
   });
 });

--- a/packages/ra-data-simple-prisma/tests/updateManyHandler.test.ts
+++ b/packages/ra-data-simple-prisma/tests/updateManyHandler.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import type { UpdateManyRequest } from "../src/Http";
+import { updateManyHandler } from "../src/updateManyHandler";
+
+jest.mock("../src/getModel");
+jest.mock("../src/audit/auditHandler");
+
+import { auditHandler } from "../src/audit/auditHandler";
+import { getModel } from "../src/getModel";
+
+const mockGetModel = getModel as jest.MockedFunction<typeof getModel>;
+const mockAuditHandler = auditHandler as jest.MockedFunction<typeof auditHandler>;
+
+function makeReq(ids: Array<string | number>, data: Record<string, unknown>, resource = "post"): UpdateManyRequest {
+  return {
+    method: "updateMany",
+    resource,
+    params: { ids, data },
+  };
+}
+
+function makeMockModel() {
+  return {
+    updateMany: jest.fn().mockResolvedValue({ count: 2 } as never),
+  };
+}
+
+describe("updateManyHandler", () => {
+  test("calls model.updateMany with reduced data and id where clause", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const result = await updateManyHandler(makeReq([1, 2], { published: true }), {} as never);
+
+    expect(model.updateMany).toHaveBeenCalledWith({
+      data: { published: true },
+      where: { id: { in: [1, 2] } },
+    });
+    expect(result).toEqual({ data: [1, 2] });
+  });
+
+  test("uses custom primaryKey in where clause", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await updateManyHandler(makeReq([10, 20], { published: true }), {} as never, {
+      primaryKey: "StatusId",
+    });
+
+    expect(model.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { StatusId: { in: [10, 20] } } }));
+  });
+
+  test("applies reduceData transformations (skipFields)", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await updateManyHandler(makeReq([1], { title: "Keep", secret: "Drop" }), {} as never, {
+      skipFields: { secret: true },
+    });
+
+    expect(model.updateMany).toHaveBeenCalledWith(expect.objectContaining({ data: { title: "Keep" } }));
+  });
+
+  test("applies reduceData transformations (set string shortcut)", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await updateManyHandler(makeReq([1, 2], { tags: [1, 2] }), {} as never, {
+      set: { tags: "id" },
+    });
+
+    expect(model.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { tags: { set: [{ id: 1 }, { id: 2 }] } },
+      }),
+    );
+  });
+
+  test("debug option logs reduced data", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await updateManyHandler(makeReq([1], { title: "Debug" }), {} as never, { debug: true });
+
+    expect(consoleSpy).toHaveBeenCalledWith("updateManyHandler:data", { title: "Debug" });
+  });
+
+  test("audit option calls auditHandler", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+    mockAuditHandler.mockResolvedValue(undefined as never);
+
+    const req = makeReq([1, 2], { published: true });
+    const auditOptions = {
+      model: { create: jest.fn() },
+      authProvider: {} as never,
+    };
+
+    await updateManyHandler(req, {} as never, { audit: auditOptions });
+
+    expect(mockAuditHandler).toHaveBeenCalledWith(req, auditOptions);
+  });
+
+  test("does not call auditHandler when audit option is absent", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    await updateManyHandler(makeReq([1], { title: "No audit" }), {} as never);
+
+    expect(mockAuditHandler).not.toHaveBeenCalled();
+  });
+
+  test("rejects payload data containing configured custom primary key field", async () => {
+    const model = makeMockModel();
+    mockGetModel.mockReturnValue(model as never);
+
+    const req = makeReq([1], { title: "Updated", StatusId: 1 });
+
+    await expect(
+      updateManyHandler(req, {} as never, {
+        primaryKey: "StatusId",
+      }),
+    ).rejects.toThrow(
+      "updateHandler: Field StatusId is reserved when primaryKey is configured; use params.id and omit the original primary key from writes",
+    );
+  });
+});


### PR DESCRIPTION
- created and updated records should use primary key option (if set)
- returned records should remap to primary key option (if set)
- full test coverage for updated files