### PR TITLE
feat: support Prisma's "omit"

### DIFF
--- a/apps/admin/CHANGELOG.md
+++ b/apps/admin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # admin
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - ra-data-simple-prisma@7.5.1
+
 ## 0.0.4
 
 ### Patch Changes

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3020",

--- a/packages/ra-data-simple-prisma/CHANGELOG.md
+++ b/packages/ra-data-simple-prisma/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ra-data-simple-prisma
 
+## 7.5.1
+
+### Patch Changes
+
+- feat: support Prisma's "omit" field
+
 ## 7.5.0
 
 ### Minor Changes

--- a/packages/ra-data-simple-prisma/package.json
+++ b/packages/ra-data-simple-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ra-data-simple-prisma",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Simple react-admin dataprovider for prisma, supporting audit logs and roles",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/ra-data-simple-prisma/src/createHandler.ts
+++ b/packages/ra-data-simple-prisma/src/createHandler.ts
@@ -10,6 +10,7 @@ import type { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 export type CreateArgs = {
   include?: object | null;
   select?: object | null;
+  omit?: object | null;
 };
 
 export type CreateOptions<Args extends CreateArgs = CreateArgs> = Args & {
@@ -135,6 +136,7 @@ export const createHandler = async <Args extends CreateArgs>(
     data,
     include: options?.include ?? undefined,
     select: options?.select ?? undefined,
+    omit: options?.omit ?? undefined,
   });
 
   if (options?.debug) console.log("createHandler:created", created);

--- a/packages/ra-data-simple-prisma/src/getListHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getListHandler.ts
@@ -10,6 +10,7 @@ import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 export type GetListArgs = {
   include?: object | null;
   select?: object | null;
+  omit?: object | null;
   where?: object | null;
   orderBy?: object | null;
 };
@@ -35,6 +36,7 @@ export const getListHandler = async <Args extends GetListArgs>(
       include?: object;
       orderBy?: object;
       select?: object;
+      omit?: object;
       skip?: number;
       take?: number;
       where: object;
@@ -49,6 +51,7 @@ export const getListHandler = async <Args extends GetListArgs>(
       include: options?.include ?? undefined,
       orderBy: options?.orderBy ?? undefined,
       select: options?.select ?? undefined,
+      omit: options?.omit ?? undefined,
       where: options?.where ?? {},
     },
     countArg: {

--- a/packages/ra-data-simple-prisma/src/getManyHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getManyHandler.ts
@@ -6,6 +6,7 @@ import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 export type GetManyArgs = {
   include?: object | null;
   select?: object | null;
+  omit?: object | null;
 };
 
 export type GetManyOptions<Args extends GetManyArgs = GetManyArgs> = Args & {
@@ -28,6 +29,7 @@ export const getManyHandler = async <Args extends GetManyArgs>(
   const rows = await model.findMany({
     include: options?.include,
     select: options?.select,
+    omit: options?.omit,
     where: { [primaryKey]: { in: ids } },
   });
 

--- a/packages/ra-data-simple-prisma/src/getManyReferenceHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getManyReferenceHandler.ts
@@ -9,6 +9,7 @@ import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 export type GetManyReferenceArgs = {
   include?: object | null;
   select?: object | null;
+  omit?: object | null;
 };
 
 export type GetManyReferenceOptions<
@@ -44,6 +45,7 @@ export const getManyReferenceHandler = async <
     model.findMany({
       include: options?.include,
       select: options?.select,
+      omit: options?.omit,
       where: { [target]: id, ...where },
       orderBy,
       skip,

--- a/packages/ra-data-simple-prisma/src/getOneHandler.ts
+++ b/packages/ra-data-simple-prisma/src/getOneHandler.ts
@@ -6,6 +6,7 @@ import { PrismaClientOrDynamicClientExtension } from "./PrismaClientTypes";
 export type GetOneArgs = {
   include?: object | null;
   select?: object | null;
+  omit?: object | null;
   // there is no where because it's always id based
 };
 
@@ -30,6 +31,7 @@ export const getOneHandler = async <Args extends GetOneArgs>(
   const row = await model.findUnique({
     where,
     select: options?.select ?? undefined,
+    omit: options?.omit ?? undefined,
     include: options?.include ?? undefined,
   });
 

--- a/packages/ra-data-simple-prisma/src/updateHandler.ts
+++ b/packages/ra-data-simple-prisma/src/updateHandler.ts
@@ -13,6 +13,7 @@ export type { SetExplicitConnection, SetImplicitConnection, SetImplicitShortcut 
 export type UpdateArgs = {
   include?: object | null;
   select?: object | null;
+  omit?: object | null;
 };
 
 export type UpdateOptions<Args extends UpdateArgs = UpdateArgs> = Args & {
@@ -181,6 +182,7 @@ export const updateHandler = async <Args extends UpdateArgs>(
     data,
     include: options?.include ?? undefined,
     select: options?.select ?? undefined,
+    omit: options?.omit ?? undefined,
     where: { [primaryKey]: id },
   });
 


### PR DESCRIPTION
It is useful because some sensitive fields can be omitted at the global prisma level, but displayed in the admin using
`opts.getOne = { omit: { sensitiveField: false } }`