### PR TITLE
feat(ra-data-simple-prisma): add /server subpath export to keep react-admin out of server bundles

### DIFF
--- a/.changeset/server-subpath-export.md
+++ b/.changeset/server-subpath-export.md
@@ -1,0 +1,17 @@
+---
+"ra-data-simple-prisma": minor
+---
+
+Add `ra-data-simple-prisma/server` subpath export for server-side use.
+
+The server entry contains only the Prisma request handlers and helpers
+and has no dependency on `react-admin` (and therefore no transitive
+dependency on `ra-core`, `ra-ui-materialui`, or `react-router-dom`).
+Importing from this subpath inside Next.js / Vercel serverless functions
+avoids tracing UI-only packages into the function bundle and fixes ESM
+resolution failures caused by `react-router-dom@7.x`'s `exports` field.
+
+The top-level `ra-data-simple-prisma` import is unchanged and still
+re-exports both the client-side `dataProvider` and the server-side
+handlers, so this is a non-breaking change. `react-admin` is now marked
+as an optional peer dependency for server-only consumers.

--- a/packages/ra-data-simple-prisma/README.md
+++ b/packages/ra-data-simple-prisma/README.md
@@ -31,13 +31,18 @@ export default ReactAdmin;
 
 ### Backend: import the request handlers
 
-Simplest implementation ever:
+Server-side code should import from the `/server` subpath. This entry
+contains only the request handlers and helpers, with no dependency on
+`react-admin` (and therefore no transitive dependency on `ra-core`,
+`ra-ui-materialui`, or `react-router-dom`). This keeps Next.js / Vercel
+serverless bundles small and avoids ESM resolution issues caused by
+tracing UI-only packages into the function.
 
 ```js
 // -- Example for Next Pages router --
 // /api/[resource].ts <= catch all resource requests
 
-import { defaultHandler } from "ra-data-simple-prisma";
+import { defaultHandler } from "ra-data-simple-prisma/server";
 import { prismaClient } from "../prisma/client"; // <= Your prisma client instance
 
 export default async function handler(req, res) {
@@ -48,7 +53,7 @@ export default async function handler(req, res) {
 // -- Example for Next App router --
 // /app/api/[resource]/route.ts <= catch all resource requests
 
-import { defaultHandler } from "ra-data-simple-prisma";
+import { defaultHandler } from "ra-data-simple-prisma/server";
 import { prismaClient } from "../prisma/client"; // <= Your prisma client instance
 import { NextResponse } from "next/server";
 
@@ -60,6 +65,11 @@ const handler = async (req: Request) => {
 
 export { handler as GET, handler as POST };
 ```
+
+> The top-level `ra-data-simple-prisma` import still re-exports the
+> handlers for backwards compatibility, but new server-side code should
+> prefer `ra-data-simple-prisma/server` so that `react-admin` stays out
+> of the server bundle.
 
 ### (List) Filters: Available Operators
 

--- a/packages/ra-data-simple-prisma/package.json
+++ b/packages/ra-data-simple-prisma/package.json
@@ -5,8 +5,24 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.mjs",
+      "require": "./dist/server.js",
+      "default": "./dist/server.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --treeshake --external react-admin --external ra-core --external ra-ui-materialui",
+    "build": "tsup src/index.ts src/server.ts --format esm,cjs --dts --treeshake --external react-admin --external ra-core --external ra-ui-materialui",
+    "build:check": "node -e \"const fs=require('fs');const files=['dist/server.js','dist/server.mjs'];for (const f of files){const c=fs.readFileSync(f,'utf8');if(/['\\\"]react-admin['\\\"]/.test(c)){console.error('FAIL: '+f+' references react-admin');process.exit(1)}}console.log('OK: server bundle has no react-admin reference')\"",
     "dev": "pnpm build --watch",
     "lint": "eslint src --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
@@ -38,6 +54,11 @@
   "peerDependencies": {
     "@prisma/client": ">=5",
     "react-admin": ">=5.7.2"
+  },
+  "peerDependenciesMeta": {
+    "react-admin": {
+      "optional": true
+    }
   },
   "dependencies": {
     "axios": "^1.13.5",

--- a/packages/ra-data-simple-prisma/src/Http.ts
+++ b/packages/ra-data-simple-prisma/src/Http.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CreateParams,
   DeleteManyParams,
   DeleteParams,

--- a/packages/ra-data-simple-prisma/src/audit/auditHandler.ts
+++ b/packages/ra-data-simple-prisma/src/audit/auditHandler.ts
@@ -1,6 +1,6 @@
 import { AuditOptions, AuditLogPayload, defaultAuditOptions } from "./types";
-import { RaPayload } from "../Http";
-import { Identifier } from "react-admin";
+import type { RaPayload } from "../Http";
+import type { Identifier } from "react-admin";
 
 export const auditHandler = async (
   request: RaPayload,

--- a/packages/ra-data-simple-prisma/src/audit/types.ts
+++ b/packages/ra-data-simple-prisma/src/audit/types.ts
@@ -1,5 +1,5 @@
 import { PlainObject } from "deverything";
-import { AuthProvider, Identifier } from "react-admin";
+import type { AuthProvider, Identifier } from "react-admin";
 
 export type AuditOptions = {
   model: { create: Function };

--- a/packages/ra-data-simple-prisma/src/server.ts
+++ b/packages/ra-data-simple-prisma/src/server.ts
@@ -1,0 +1,28 @@
+// Server-only entry point.
+// This module intentionally excludes any code that depends on `react-admin`
+// (notably the `dataProvider` and `HttpError`) so that Next.js / Vercel
+// serverless functions importing handlers do not transitively pull in
+// `react-admin`, `ra-core`, `ra-ui-materialui`, or `react-router-dom`.
+//
+// Use `ra-data-simple-prisma/server` from server-side code, and the
+// top-level `ra-data-simple-prisma` import from client-side code.
+
+export * from "./audit";
+export * from "./createHandler";
+export * from "./defaultHandler";
+export * from "./deleteHandler";
+export * from "./deleteManyHandler";
+export * from "./extractOrderBy";
+export * from "./extractSkipTake";
+export * from "./extractWhere";
+export * from "./getInfiniteListHandler";
+export * from "./getListHandler";
+export * from "./getManyHandler";
+export * from "./getManyReferenceHandler";
+export * from "./getOneHandler";
+export * from "./hasFieldChanged";
+export * from "./Http";
+export * from "./isExport";
+export * from "./permissions";
+export * from "./updateHandler";
+export * from "./updateManyHandler";

--- a/packages/ra-data-simple-prisma/tests/serverBundle.test.ts
+++ b/packages/ra-data-simple-prisma/tests/serverBundle.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "@jest/globals";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+const distDir = join(__dirname, "..", "dist");
+
+// These tests only run if `pnpm build` has been executed beforehand.
+// They guard against a regression in which the server-only entry
+// transitively imports `react-admin`, which would pull react-admin (and
+// its transitive deps) into Next.js / Vercel serverless bundles that
+// only need the Prisma-side handlers.
+const maybeDescribe = existsSync(join(distDir, "server.js")) ? describe : describe.skip;
+
+maybeDescribe("dist/server bundle", () => {
+  test("CJS server bundle does not reference react-admin", () => {
+    const contents = readFileSync(join(distDir, "server.js"), "utf8");
+    expect(contents).not.toMatch(/['"]react-admin['"]/);
+  });
+
+  test("ESM server bundle does not reference react-admin", () => {
+    const contents = readFileSync(join(distDir, "server.mjs"), "utf8");
+    expect(contents).not.toMatch(/['"]react-admin['"]/);
+  });
+});


### PR DESCRIPTION
Hi, I was having an issue with a project that uses this package and I've had to resolve temporarily, using resolutions in my package.json. Have used claude to raise this PR which fixes my issue. Would be great if you could consider merging. 

Disclaimer: I haven't looked in-depth at this code and I'm not familiar with this repo, so please review carefully! Hopefully it's not just AI slop!


## Summary

`ra-data-simple-prisma` exposes both a client-side `dataProvider` (used
by react-admin in the browser) and server-side request handlers (used
inside Next.js API routes to talk to Prisma directly) from a single
bundle. That bundle has a top-level `import { HttpError } from 'react-admin'`
which is only used by the client `dataProvider`, but because it sits at
the top of `dist/index.js` / `dist/index.mjs`, **any server-side import
of a handler transitively pulls in `react-admin`, `ra-core`,
`ra-ui-materialui`, and `react-router-dom`** at runtime.

On Vercel / Next.js this causes two real problems:

1. The serverless function bundle is bloated with UI-only packages it
   never executes.
2. ESM resolution can break the deployment. With `react-router-dom@7.x`
   the package's `exports` field causes Next.js NFT (file tracer) to
   include `dist/index.js` (CJS) while Node ESM resolution at runtime
   picks `dist/index.mjs` — the missing `.mjs` is then never traced and
   the function crashes with `MODULE_NOT_FOUND` in production.

### Fix

Split into two entry points via subpath exports:

| Entry | Contents | Pulls in `react-admin`? |
| --- | --- | --- |
| `ra-data-simple-prisma` | `dataProvider` + handlers (back-compat) | yes (unchanged) |
| `ra-data-simple-prisma/server` | handlers + helpers only | **no** |

Server-side consumers can switch to:

```ts
import { defaultHandler } from "ra-data-simple-prisma/server";
```

and `react-admin` (plus its transitive UI deps) disappears from the
function's traced files entirely.

### Changes

- New `src/server.ts` entry that re-exports only the server APIs.
- `Http.ts`, `audit/types.ts`, `audit/auditHandler.ts` now use
  `import type` for their `react-admin` imports — these were already
  type-only usages, but the explicit `type` keyword guarantees esbuild
  erases them at build time so the server bundle has no `require('react-admin')`.
- `package.json`:
  - `exports` map for `.` (back-compat) and `./server` with `.d.ts`,
    ESM, and CJS targets for each.
  - `tsup` now builds both entries.
  - `react-admin` moved to `peerDependenciesMeta.optional = true` so
    server-only consumers don't get install warnings.
  - New `build:check` script that asserts the server bundle has no
    `react-admin` reference.
- `tests/serverBundle.test.ts` — Jest guard that fails CI if `dist/server.{js,mjs}`
  ever start referencing `react-admin` again.
- README documents the new `/server` subpath.
- Changeset (minor bump).

### Non-breaking

The top-level entry is unchanged: it still re-exports both the
`dataProvider` and the handlers, so existing imports continue to work
without modification.

## Test plan

- [x] `pnpm build` produces `dist/index.{js,mjs,d.ts}` and `dist/server.{js,mjs,d.ts}`
- [x] `grep react-admin dist/server.*` returns nothing
- [x] `pnpm test` passes (164/164, including the new `serverBundle.test.ts`)
- [x] `pnpm build:check` passes
- [ ] Manual: import `from "ra-data-simple-prisma/server"` in a Next.js
      App Router function on Vercel, confirm the function bundle no
      longer traces `react-admin` / `react-router-dom`